### PR TITLE
Support int fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "scripts": {
     "protores": "NODE_PATH=packages/bs-protobuf packages/bs-protobuf/src/script/protores.js",
     "protores:build": "yarn workspace @reproto/bs-protobuf protores:build && yarn workspace @reproto/bs-rpc-axios protores:build && yarn workspace @reproto/proto-demo protores:build",
+    "protores:dev": "yarn protores:build && yarn workspace @reproto/bs-protobuf protores:dev & yarn workspace @reproto/bs-rpc-axios protores:dev & yarn workspace @reproto/proto-demo protores:dev",
     "rescript:build": "rescript build -with-deps",
     "rescript:dev": "NINJA_ANSI_FORCED=1 RES_LOG=info rescript build -w -with-deps",
     "bs-protobuf:build": "yarn workspace @reproto/bs-protobuf build",

--- a/packages/bs-protobuf/src/api/ProtoTypeSupport.res
+++ b/packages/bs-protobuf/src/api/ProtoTypeSupport.res
@@ -4,40 +4,6 @@ external decode: (Js_typed_array.ArrayBuffer.t, _) => 'a = "d"
 external encode: (_, _) => Js_typed_array.array_buffer = "e"
 @module("@reproto/bs-protobuf/src/api/proto-type-support")
 external verify: ('a, _) => option<string> = "v"
-module FromRecord = {
-  @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("fromRecord")
-  external string: ('a, string, _) => 'a = "string"
-  @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("fromRecord")
-  external int32: ('a, string, _) => 'a = "int32"
-  @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("fromRecord")
-  external int64: ('a, string, _) => 'a = "int64"
-  @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("fromRecord")
-  external bytes: ('a, string, _) => 'a = "bytes"
-  @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("fromRecord")
-  external enum: ('a, string, _) => 'a = "enum"
-  @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("fromRecord")
-  external message: ('a, string, _) => 'a = "message"
-  @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("fromRecord")
-  external oneof: ('a, string, _, _) => 'a = "oneof"
-}
-module ToRecord = {
-  @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("toRecord")
-  external string: ('a, string, _) => 'a = "string"
-  @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("toRecord")
-  external int32: ('a, string, _) => 'a = "int32"
-  @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("toRecord")
-  external int64: ('a, string, _) => 'a = "int64"
-  @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("toRecord")
-  external bytes: ('a, string, _) => 'a = "bytes"
-  @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("toRecord")
-  external enum: ('a, string, _) => 'a = "enum"
-  @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("toRecord")
-  external message: ('a, string, _) => 'a = "message"
-  @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("toRecord")
-  external oneof: ('a, string, _, _) => 'a = "oneof"
-}
-
-// New style conversion
 
 module Field = {
   @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("field")

--- a/packages/bs-protobuf/src/api/ProtoTypeSupport.res
+++ b/packages/bs-protobuf/src/api/ProtoTypeSupport.res
@@ -25,6 +25,14 @@ module Convert = {
   @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("Convert") @val
   external int32: _ = "int32"
   @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("Convert") @val
+  external uint32: _ = "uint32"
+  @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("Convert") @val
+  external sint32: _ = "sint32"
+  @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("Convert") @val
+  external fixed32: _ = "fixed32"
+  @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("Convert") @val
+  external sfixed32: _ = "sfixed32"
+  @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("Convert") @val
   external int64: _ = "int64"
   @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("Convert") @val
   external uint64: _ = "uint64"
@@ -33,7 +41,7 @@ module Convert = {
   @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("Convert") @val
   external fixed64: _ = "fixed64"
   @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("Convert") @val
-  external sfixed64: _ = "sfixed4"
+  external sfixed64: _ = "sfixed64"
   @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("Convert") @val
   external bytes: _ = "bytes"
   @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("Convert") @val

--- a/packages/bs-protobuf/src/api/ProtoTypeSupport.res
+++ b/packages/bs-protobuf/src/api/ProtoTypeSupport.res
@@ -27,6 +27,14 @@ module Convert = {
   @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("Convert") @val
   external int64: _ = "int64"
   @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("Convert") @val
+  external uint64: _ = "uint64"
+  @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("Convert") @val
+  external sint64: _ = "sint64"
+  @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("Convert") @val
+  external fixed64: _ = "fixed64"
+  @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("Convert") @val
+  external sfixed64: _ = "sfixed4"
+  @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("Convert") @val
   external bytes: _ = "bytes"
   @module("@reproto/bs-protobuf/src/api/proto-type-support") @scope("Convert") @val
   external enum: _ = "enum"

--- a/packages/bs-protobuf/src/api/proto-type-support.js
+++ b/packages/bs-protobuf/src/api/proto-type-support.js
@@ -18,6 +18,76 @@ export function d(b, messageClass) {
   return message;
 }
 
+// Conversion helpers
+
+const int32 = {
+  fromR(v) {
+    if (v != null) {
+      return { m: v | 0 };
+    }
+  },
+
+  toR({ has, m }) {
+    if (has && m != null) {
+      return { v: m };
+    }
+  },
+};
+
+const int64 = {
+  fromR(v) {
+    if (v != null) {
+      return { m: new util.Long(v[1], v[0], false) };
+    }
+  },
+
+  toR({ has, m }) {
+    if (has && m != null) {
+      return { v: [m.high, m.low >>> 0] };
+    }
+  },
+};
+
+class OneofConverter {
+  constructor(choices) {
+    this.choices = choices;
+  }
+
+  fromR(v) {
+    if (v !== 0) {
+      const [type, key] = this.choices[v.TAG];
+      const result = Convert[type].fromR(v._0);
+      if (result) {
+        if (result.key) {
+          throw new Error(`Oneof cannot be duplicated [${key}]`);
+        }
+        return { m: result.m, key };
+      }
+    }
+  }
+
+  toR({ message }) {
+    if (!message) {
+      throw new Error("Oneof cannot ve repeated");
+    }
+    for (let i = 0; i < this.choices.length; i++) {
+      const [type, subKey] = this.choices[i];
+      if (type === "") {
+        // skip terminator for 1-tuples
+        continue;
+      }
+      const f = message[subKey];
+      if (f != null) {
+        const result = Convert[type].toR({ has: true, m: f });
+        if (result !== undefined) {
+          return { v: { TAG: i, _0: result.v } };
+        }
+      }
+    }
+    return { v: 0 };
+  }
+}
+
 // Field mapping
 
 export const field = {
@@ -95,33 +165,17 @@ export const Convert = {
     },
   },
 
-  int32: {
-    fromR(v) {
-      if (v != null) {
-        return { m: v | 0 };
-      }
-    },
+  int32,
 
-    toR({ has, m }) {
-      if (has && m != null) {
-        return { v: m };
-      }
-    },
-  },
+  int64,
 
-  int64: {
-    fromR(v) {
-      if (v != null) {
-        return { m: new util.Long(v[1], v[0], false) };
-      }
-    },
+  uint64: int64,
 
-    toR({ has, m }) {
-      if (has && m != null) {
-        return { v: [m.high, m.low >>> 0] };
-      }
-    },
-  },
+  sint64: int64,
+
+  fixed64: int64,
+
+  sfixed64: int64,
 
   bytes: {
     fromR(v) {
@@ -137,19 +191,7 @@ export const Convert = {
     },
   },
 
-  enum: {
-    fromR(v) {
-      if (v != null) {
-        return { m: v | 0 };
-      }
-    },
-
-    toR({ has, m }) {
-      if (has && m != null) {
-        return { v: m };
-      }
-    },
-  },
+  enum: int32,
 
   message: {
     fromR(v) {
@@ -169,45 +211,3 @@ export const Convert = {
     return new OneofConverter(choices);
   },
 };
-
-// Oneof conversion
-
-class OneofConverter {
-  constructor(choices) {
-    this.choices = choices;
-  }
-
-  fromR(v) {
-    if (v !== 0) {
-      const [type, key] = this.choices[v.TAG];
-      const result = Convert[type].fromR(v._0);
-      if (result) {
-        if (result.key) {
-          throw new Error(`Oneof cannot be duplicated [${key}]`);
-        }
-        return { m: result.m, key };
-      }
-    }
-  }
-
-  toR({ message }) {
-    if (!message) {
-      throw new Error("Oneof cannot ve repeated");
-    }
-    for (let i = 0; i < this.choices.length; i++) {
-      const [type, subKey] = this.choices[i];
-      if (type === "") {
-        // skip terminator for 1-tuples
-        continue;
-      }
-      const f = message[subKey];
-      if (f != null) {
-        const result = Convert[type].toR({ has: true, m: f });
-        if (result !== undefined) {
-          return { v: { TAG: i, _0: result.v } };
-        }
-      }
-    }
-    return { v: 0 };
-  }
-}

--- a/packages/bs-protobuf/src/api/proto-type-support.js
+++ b/packages/bs-protobuf/src/api/proto-type-support.js
@@ -20,6 +20,8 @@ export function d(b, messageClass) {
 
 // Conversion helpers
 
+const maxSafe32 = 2147483647;
+
 const int32 = {
   fromR(v) {
     if (v != null) {
@@ -29,6 +31,11 @@ const int32 = {
 
   toR({ has, m }) {
     if (has && m != null) {
+      if (m > maxSafe32) {
+        // Overflow to negatives to make sure
+        // that we return a safe value
+        m -= 2 * (maxSafe32 + 1);
+      }
       return { v: m };
     }
   },
@@ -166,6 +173,14 @@ export const Convert = {
   },
 
   int32,
+
+  uint32: int32,
+
+  sint32: int32,
+
+  fixed32: int32,
+
+  sfixed32: int32,
 
   int64,
 

--- a/packages/bs-protobuf/src/compiler/gen-types.js
+++ b/packages/bs-protobuf/src/compiler/gen-types.js
@@ -147,6 +147,10 @@ function mapFieldType(
   const result = {
     string: "string",
     int32: "int",
+    uint32: "int",
+    sint32: "int",
+    fixed32: "int",
+    sfixed32: "int",
     int64: "int64",
     uint64: "int64",
     sint64: "int64",
@@ -206,6 +210,10 @@ function defaultFieldValue(field: Object, lookup: Function) {
     const result = {
       string: '""',
       int32: "0",
+      uint32: "0",
+      sint32: "0",
+      fixed32: "0",
+      sfixed32: "0",
       int64: 'Int64.of_string("0")',
       uint64: 'Int64.of_string("0")',
       sint64: 'Int64.of_string("0")',

--- a/packages/bs-protobuf/src/compiler/gen-types.js
+++ b/packages/bs-protobuf/src/compiler/gen-types.js
@@ -148,6 +148,10 @@ function mapFieldType(
     string: "string",
     int32: "int",
     int64: "int64",
+    uint64: "int64",
+    sint64: "int64",
+    fixed64: "int64",
+    sfixed64: "int64",
     bytes: "Js_typed_array.Uint8Array.t",
   }[fieldType];
   if (result !== undefined) {
@@ -203,6 +207,10 @@ function defaultFieldValue(field: Object, lookup: Function) {
       string: '""',
       int32: "0",
       int64: 'Int64.of_string("0")',
+      uint64: 'Int64.of_string("0")',
+      sint64: 'Int64.of_string("0")',
+      fixed64: 'Int64.of_string("0")',
+      sfixed64: 'Int64.of_string("0")',
       bytes: "Js_typed_array.Uint8Array.make([])",
     }[fieldType];
     if (result !== undefined) {

--- a/packages/bs-protobuf/test/__tests__/FieldTypes3_test.res
+++ b/packages/bs-protobuf/test/__tests__/FieldTypes3_test.res
@@ -83,17 +83,56 @@ describe("Protobuf field types support", () => {
       )
     })
 
-    describe("int32", () => {
-      let v = Typeful.make(~int32Field=Some(4), ())
-      test("value", () => v.int32Field |> expect |> toBe(Some(4)))
+    let testInt32 = (makeValue, getField) => {
+      let v = makeValue(Some(4))
+      test("value", () => v |> getField |> expect |> toBe(Some(4)))
       test("encode/decode", () =>
-        v |> Typeful.encode |> Typeful.decode |> (v => v.int32Field) |> expect |> toBe(Some(4))
+        v |> Typeful.encode |> Typeful.decode |> getField |> expect |> toBe(Some(4))
+      )
+      let field = -4
+      let v = makeValue(Some(field))
+      test("negative", () => v |> getField |> expect |> toBe(Some(field)))
+      test("negative encode/decode", () =>
+        v |> Typeful.encode |> Typeful.decode |> getField |> expect |> toBe(Some(field))
+      )
+      let maxSafe = 2147483647
+      let field = maxSafe
+      let v = makeValue(Some(field))
+      test("max safe", () => v |> getField |> expect |> toBe(Some(field)))
+      test("max safe encode/decode", () =>
+        v |> Typeful.encode |> Typeful.decode |> getField |> expect |> toBe(Some(field))
+      )
+      let field = -maxSafe
+      let v = makeValue(Some(field))
+      test("min safe", () => v |> getField |> expect |> toBe(Some(field)))
+      test("min safe encode/decode", () =>
+        v |> Typeful.encode |> Typeful.decode |> getField |> expect |> toBe(Some(field))
       )
       let empty = Typeful.make()
-      test("empty", () => empty.int32Field |> expect |> toBe(None))
+      test("empty", () => empty |> getField |> expect |> toBe(None))
       test("empty encode/decode", () =>
-        empty |> Typeful.encode |> Typeful.decode |> (v => v.int32Field) |> expect |> toBe(None)
+        empty |> Typeful.encode |> Typeful.decode |> getField |> expect |> toBe(None)
       )
+    }
+
+    describe("int32", () => {
+      testInt32(int32Field => Typeful.make(~int32Field, ()), v => v.int32Field)
+    })
+
+    describe("uint32", () => {
+      testInt32(uint32Field => Typeful.make(~uint32Field, ()), v => v.uint32Field)
+    })
+
+    describe("sint32", () => {
+      testInt32(sint32Field => Typeful.make(~sint32Field, ()), v => v.sint32Field)
+    })
+
+    describe("fixed32", () => {
+      testInt32(fixed32Field => Typeful.make(~fixed32Field, ()), v => v.fixed32Field)
+    })
+
+    describe("sfixed32", () => {
+      testInt32(sfixed32Field => Typeful.make(~sfixed32Field, ()), v => v.sfixed32Field)
     })
 
     let testInt64 = (makeValue, getField) => {

--- a/packages/bs-protobuf/test/__tests__/FieldTypes3_test.res
+++ b/packages/bs-protobuf/test/__tests__/FieldTypes3_test.res
@@ -96,29 +96,49 @@ describe("Protobuf field types support", () => {
       )
     })
 
-    describe("int64", () => {
+    let testInt64 = (makeValue, getField) => {
       let testEncode = (v, f, ()) =>
-        v |> Typeful.encode |> Typeful.decode |> (v => v.int64Field) |> expect |> toEqual(f)
-      let int64Field = Some(Int64.of_string("4"))
-      let v = Typeful.make(~int64Field, ())
-      test("value", () => v.int64Field |> expect |> toEqual(int64Field))
-      test("encode/decode", testEncode(v, int64Field))
+        v |> Typeful.encode |> Typeful.decode |> getField |> expect |> toEqual(f)
+      let field = Some(Int64.of_string("4"))
+      let v = makeValue(field)
+      test("value", () => v |> getField |> expect |> toEqual(field))
+      test("encode/decode", testEncode(v, field))
       let v = Typeful.make()
-      test("empty", () => v.int64Field |> expect |> toBe(None))
+      test("empty", () => v |> getField |> expect |> toBe(None))
       test("empty encode/decode", testEncode(v, None))
       let largeString = "9007199254740992" // Number.MAX_SAFE_INTEGER + 1
-      let int64Field = Some(Int64.of_string(largeString))
-      let v = Typeful.make(~int64Field, ())
-      test("maxvalue", () => v.int64Field |> expect |> toEqual(int64Field))
-      test("maxvalue encode/decode", testEncode(v, int64Field))
-      let int64Field = Some(Int64.of_string("4"))
-      let v = Typeful.make(~int64Field, ())
-      test("negative", () => v.int64Field |> expect |> toEqual(int64Field))
-      test("negative encode/decode", testEncode(v, int64Field))
-      let int64Field = Some(Int64.of_string("-" ++ largeString))
-      let v = Typeful.make(~int64Field, ())
-      test("minvalue", () => v.int64Field |> expect |> toEqual(int64Field))
-      test("minvalue encode/decode", testEncode(v, int64Field))
+      let field = Some(Int64.of_string(largeString))
+      let v = makeValue(field)
+      test("maxvalue", () => v |> getField |> expect |> toEqual(field))
+      test("maxvalue encode/decode", testEncode(v, field))
+      let field = Some(Int64.of_string("4"))
+      let v = makeValue(field)
+      test("negative", () => v |> getField |> expect |> toEqual(field))
+      test("negative encode/decode", testEncode(v, field))
+      let field = Some(Int64.of_string("-" ++ largeString))
+      let v = makeValue(field)
+      test("minvalue", () => v |> getField |> expect |> toEqual(field))
+      test("minvalue encode/decode", testEncode(v, field))
+    }
+
+    describe("int64", () => {
+      testInt64(int64Field => Typeful.make(~int64Field, ()), v => v.int64Field)
+    })
+
+    describe("uint64", () => {
+      testInt64(uint64Field => Typeful.make(~uint64Field, ()), v => v.uint64Field)
+    })
+
+    describe("sint64", () => {
+      testInt64(sint64Field => Typeful.make(~sint64Field, ()), v => v.sint64Field)
+    })
+
+    describe("fixed64", () => {
+      testInt64(fixed64Field => Typeful.make(~fixed64Field, ()), v => v.fixed64Field)
+    })
+
+    describe("sfixed64", () => {
+      testInt64(sfixed64Field => Typeful.make(~sfixed64Field, ()), v => v.sfixed64Field)
     })
 
     describe("bytes", () => {
@@ -194,7 +214,12 @@ describe("Protobuf field types support", () => {
 
     describe("repeated", () => {
       let testMessage = (v, f, ()) =>
-        v |> Typeful.encode |> Typeful.decode |> (v => v.repeatedStringField) |> expect |> toEqual(f)
+        v
+        |> Typeful.encode
+        |> Typeful.decode
+        |> (v => v.repeatedStringField)
+        |> expect
+        |> toEqual(f)
       let repeatedStringField = ["a", "b", "c"]
       let v = Typeful.make(~repeatedStringField, ())
       test("value", () => v.repeatedStringField |> expect |> toEqual(repeatedStringField))

--- a/packages/bs-protobuf/test/__tests__/FieldTypes_test.res
+++ b/packages/bs-protobuf/test/__tests__/FieldTypes_test.res
@@ -96,64 +96,68 @@ describe("Protobuf field types support", () => {
       )
     })
 
-    describe("int64", () => {
-      let v = Typeful.make(~int64Field=Int64.of_string("4"), ())
-      test("value", () => v.int64Field |> Int64.to_string |> expect |> toBe("4"))
+    let testInt64 = (makeValue, getField) => {
+      let v = makeValue(Int64.of_string("4"))
+      test("value", () => v |> getField |> Int64.to_string |> expect |> toBe("4"))
       test("encode/decode", () =>
-        v
-        |> Typeful.encode
-        |> Typeful.decode
-        |> (v => v.int64Field)
-        |> Int64.to_string
-        |> expect
-        |> toBe("4")
+        v |> Typeful.encode |> Typeful.decode |> getField |> Int64.to_string |> expect |> toBe("4")
       )
       let v = Typeful.make()
-      test("empty", () => v.int64Field |> Int64.to_string |> expect |> toBe("0"))
+      test("empty", () => v |> getField |> Int64.to_string |> expect |> toBe("0"))
       test("empty encode/decode", () =>
-        v
-        |> Typeful.encode
-        |> Typeful.decode
-        |> (v => v.int64Field)
-        |> Int64.to_string
-        |> expect
-        |> toBe("0")
+        v |> Typeful.encode |> Typeful.decode |> getField |> Int64.to_string |> expect |> toBe("0")
       )
       let largeString = "9007199254740992" // Number.MAX_SAFE_INTEGER + 1
-      let v = Typeful.make(~int64Field=Int64.of_string(largeString), ())
-      test("maxvalue", () => v.int64Field |> Int64.to_string |> expect |> toBe(largeString))
+      let v = makeValue(Int64.of_string(largeString))
+      test("maxvalue", () => v |> getField |> Int64.to_string |> expect |> toBe(largeString))
       test("maxvalue encode/decode", () =>
         v
         |> Typeful.encode
         |> Typeful.decode
-        |> (v => v.int64Field)
+        |> getField
         |> Int64.to_string
         |> expect
         |> toBe(largeString)
       )
-      let v = Typeful.make(~int64Field=Int64.of_string("-4"), ())
-      test("negative", () => v.int64Field |> Int64.to_string |> expect |> toBe("-4"))
+      let v = makeValue(Int64.of_string("-4"))
+      test("negative", () => v |> getField |> Int64.to_string |> expect |> toBe("-4"))
       test("negative encode/decode", () =>
-        v
-        |> Typeful.encode
-        |> Typeful.decode
-        |> (v => v.int64Field)
-        |> Int64.to_string
-        |> expect
-        |> toBe("-4")
+        v |> Typeful.encode |> Typeful.decode |> getField |> Int64.to_string |> expect |> toBe("-4")
       )
       let largeNegativeString = "-" ++ largeString
-      let v = Typeful.make(~int64Field=Int64.of_string(largeNegativeString), ())
-      test("maxvalue", () => v.int64Field |> Int64.to_string |> expect |> toBe(largeNegativeString))
+      let v = makeValue(Int64.of_string(largeNegativeString))
+      test("maxvalue", () =>
+        v |> getField |> Int64.to_string |> expect |> toBe(largeNegativeString)
+      )
       test("maxvalue encode/decode", () =>
         v
         |> Typeful.encode
         |> Typeful.decode
-        |> (v => v.int64Field)
+        |> getField
         |> Int64.to_string
         |> expect
         |> toBe(largeNegativeString)
       )
+    }
+
+    describe("int64", () => {
+      testInt64(int64Field => Typeful.make(~int64Field, ()), v => v.int64Field)
+    })
+
+    describe("uint64", () => {
+      testInt64(uint64Field => Typeful.make(~uint64Field, ()), v => v.uint64Field)
+    })
+
+    describe("sint64", () => {
+      testInt64(sint64Field => Typeful.make(~sint64Field, ()), v => v.sint64Field)
+    })
+
+    describe("fixed64", () => {
+      testInt64(fixed64Field => Typeful.make(~fixed64Field, ()), v => v.fixed64Field)
+    })
+
+    describe("sfixed64", () => {
+      testInt64(sfixed64Field => Typeful.make(~sfixed64Field, ()), v => v.sfixed64Field)
     })
 
     describe("bytes", () => {
@@ -161,18 +165,18 @@ describe("Protobuf field types support", () => {
       let v = Typeful.make(~bytesField=buffer, ())
       test("value", () => v.bytesField |> expect |> toBe(buffer))
       test("encode/decode", () =>
-        v
-        |> Typeful.encode
-        |> Typeful.decode
-        |> (v => v.bytesField)
-        |> expect
-        |> toEqual(buffer)
+        v |> Typeful.encode |> Typeful.decode |> (v => v.bytesField) |> expect |> toEqual(buffer)
       )
       let empty = Typeful.make()
       let buffer = Js_typed_array.Uint8Array.make([])
       test("empty", () => empty.bytesField |> expect |> toEqual(buffer))
       test("empty encode/decode", () =>
-        empty |> Typeful.encode |> Typeful.decode |> (v => v.bytesField) |> expect |> toEqual(buffer)
+        empty
+        |> Typeful.encode
+        |> Typeful.decode
+        |> (v => v.bytesField)
+        |> expect
+        |> toEqual(buffer)
       )
       let v = Typeful.make(~bytesField=buffer, ())
       test("zero length", () => v.bytesField |> expect |> toEqual(buffer))
@@ -269,7 +273,12 @@ describe("Protobuf field types support", () => {
 
     describe("repeated", () => {
       let testMessage = (v, f, ()) =>
-        v |> Typeful.encode |> Typeful.decode |> (v => v.repeatedStringField) |> expect |> toEqual(f)
+        v
+        |> Typeful.encode
+        |> Typeful.decode
+        |> (v => v.repeatedStringField)
+        |> expect
+        |> toEqual(f)
       let repeatedStringField = ["a", "b", "c"]
       let v = Typeful.make(~repeatedStringField, ())
       test("value", () => v.repeatedStringField |> expect |> toEqual(repeatedStringField))
@@ -278,6 +287,5 @@ describe("Protobuf field types support", () => {
       test("empty", () => v.repeatedStringField |> expect |> toEqual([]))
       test("empty encode/decode", testMessage(v, []))
     })
-
   })
 })

--- a/packages/bs-protobuf/test/__tests__/FieldTypes_test.res
+++ b/packages/bs-protobuf/test/__tests__/FieldTypes_test.res
@@ -83,17 +83,56 @@ describe("Protobuf field types support", () => {
       )
     })
 
-    describe("int32", () => {
-      let v = Typeful.make(~int32Field=4, ())
-      test("value", () => v.int32Field |> expect |> toBe(4))
+    let testInt32 = (makeValue, getField) => {
+      let v = makeValue(4)
+      test("value", () => v |> getField |> expect |> toBe(4))
       test("encode/decode", () =>
-        v |> Typeful.encode |> Typeful.decode |> (v => v.int32Field) |> expect |> toBe(4)
+        v |> Typeful.encode |> Typeful.decode |> getField |> expect |> toBe(4)
+      )
+      let field = -4
+      let v = makeValue(field)
+      test("negative", () => v |> getField |> expect |> toBe(field))
+      test("negative encode/decode", () =>
+        v |> Typeful.encode |> Typeful.decode |> getField |> expect |> toBe(field)
+      )
+      let maxSafe = 2147483647
+      let field = maxSafe
+      let v = makeValue(field)
+      test("max safe", () => v |> getField |> expect |> toBe(field))
+      test("max safe encode/decode", () =>
+        v |> Typeful.encode |> Typeful.decode |> getField |> expect |> toBe(field)
+      )
+      let field = -maxSafe
+      let v = makeValue(field)
+      test("min safe", () => v |> getField |> expect |> toBe(field))
+      test("min safe encode/decode", () =>
+        v |> Typeful.encode |> Typeful.decode |> getField |> expect |> toBe(field)
       )
       let empty = Typeful.make()
-      test("empty", () => empty.int32Field |> expect |> toBe(0))
+      test("empty", () => empty |> getField |> expect |> toBe(0))
       test("empty encode/decode", () =>
-        empty |> Typeful.encode |> Typeful.decode |> (v => v.int32Field) |> expect |> toBe(0)
+        empty |> Typeful.encode |> Typeful.decode |> getField |> expect |> toBe(0)
       )
+    }
+
+    describe("int32", () => {
+      testInt32(int32Field => Typeful.make(~int32Field, ()), v => v.int32Field)
+    })
+
+    describe("uint32", () => {
+      testInt32(uint32Field => Typeful.make(~uint32Field, ()), v => v.uint32Field)
+    })
+
+    describe("sint32", () => {
+      testInt32(sint32Field => Typeful.make(~sint32Field, ()), v => v.sint32Field)
+    })
+
+    describe("fixed32", () => {
+      testInt32(fixed32Field => Typeful.make(~fixed32Field, ()), v => v.fixed32Field)
+    })
+
+    describe("sfixed32", () => {
+      testInt32(sfixed32Field => Typeful.make(~sfixed32Field, ()), v => v.sfixed32Field)
     })
 
     let testInt64 = (makeValue, getField) => {

--- a/packages/bs-protobuf/test/proto-res/Proto.proto.js
+++ b/packages/bs-protobuf/test/proto-res/Proto.proto.js
@@ -429,6 +429,10 @@ export const typeTest = $root.typeTest = (() => {
         Typeful.prototype.int64Value = null;
         Typeful.prototype.repeatedStringField = $util.emptyArray;
         Typeful.prototype.bytesField = $util.newBuffer([]);
+        Typeful.prototype.uint64Field = $util.Long ? $util.Long.fromBits(0,0,true) : 0;
+        Typeful.prototype.sint64Field = $util.Long ? $util.Long.fromBits(0,0,true) : 0;
+        Typeful.prototype.fixed64Field = $util.Long ? $util.Long.fromBits(0,0,true) : 0;
+        Typeful.prototype.sfixed64Field = $util.Long ? $util.Long.fromBits(0,0,true) : 0;
 
         let $oneOfFields;
 
@@ -465,6 +469,14 @@ export const typeTest = $root.typeTest = (() => {
                     writer.uint32(74).string(message.repeatedStringField[i]);
             if (message.bytesField != null && Object.hasOwnProperty.call(message, "bytesField"))
                 writer.uint32(82).bytes(message.bytesField);
+            if (message.uint64Field != null && Object.hasOwnProperty.call(message, "uint64Field"))
+                writer.uint32(88).uint64(message.uint64Field);
+            if (message.sint64Field != null && Object.hasOwnProperty.call(message, "sint64Field"))
+                writer.uint32(96).uint64(message.sint64Field);
+            if (message.fixed64Field != null && Object.hasOwnProperty.call(message, "fixed64Field"))
+                writer.uint32(104).uint64(message.fixed64Field);
+            if (message.sfixed64Field != null && Object.hasOwnProperty.call(message, "sfixed64Field"))
+                writer.uint32(112).uint64(message.sfixed64Field);
             return writer;
         };
 
@@ -510,6 +522,18 @@ export const typeTest = $root.typeTest = (() => {
                     break;
                 case 10:
                     message.bytesField = reader.bytes();
+                    break;
+                case 11:
+                    message.uint64Field = reader.uint64();
+                    break;
+                case 12:
+                    message.sint64Field = reader.uint64();
+                    break;
+                case 13:
+                    message.fixed64Field = reader.uint64();
+                    break;
+                case 14:
+                    message.sfixed64Field = reader.uint64();
                     break;
                 default:
                     reader.skipType(tag & 7);
@@ -703,6 +727,10 @@ export const typeTest3 = $root.typeTest3 = (() => {
         Typeful.prototype.int64Value = null;
         Typeful.prototype.repeatedStringField = $util.emptyArray;
         Typeful.prototype.bytesField = null;
+        Typeful.prototype.uint64Field = null;
+        Typeful.prototype.sint64Field = null;
+        Typeful.prototype.fixed64Field = null;
+        Typeful.prototype.sfixed64Field = null;
 
         let $oneOfFields;
 
@@ -746,6 +774,26 @@ export const typeTest3 = $root.typeTest3 = (() => {
             set: $util.oneOfSetter($oneOfFields)
         });
 
+        Object.defineProperty(Typeful.prototype, "_uint64Field", {
+            get: $util.oneOfGetter($oneOfFields = ["uint64Field"]),
+            set: $util.oneOfSetter($oneOfFields)
+        });
+
+        Object.defineProperty(Typeful.prototype, "_sint64Field", {
+            get: $util.oneOfGetter($oneOfFields = ["sint64Field"]),
+            set: $util.oneOfSetter($oneOfFields)
+        });
+
+        Object.defineProperty(Typeful.prototype, "_fixed64Field", {
+            get: $util.oneOfGetter($oneOfFields = ["fixed64Field"]),
+            set: $util.oneOfSetter($oneOfFields)
+        });
+
+        Object.defineProperty(Typeful.prototype, "_sfixed64Field", {
+            get: $util.oneOfGetter($oneOfFields = ["sfixed64Field"]),
+            set: $util.oneOfSetter($oneOfFields)
+        });
+
         Typeful.create = function create(properties) {
             return new Typeful(properties);
         };
@@ -774,6 +822,14 @@ export const typeTest3 = $root.typeTest3 = (() => {
                     writer.uint32(74).string(message.repeatedStringField[i]);
             if (message.bytesField != null && Object.hasOwnProperty.call(message, "bytesField"))
                 writer.uint32(82).bytes(message.bytesField);
+            if (message.uint64Field != null && Object.hasOwnProperty.call(message, "uint64Field"))
+                writer.uint32(88).uint64(message.uint64Field);
+            if (message.sint64Field != null && Object.hasOwnProperty.call(message, "sint64Field"))
+                writer.uint32(96).sint64(message.sint64Field);
+            if (message.fixed64Field != null && Object.hasOwnProperty.call(message, "fixed64Field"))
+                writer.uint32(105).fixed64(message.fixed64Field);
+            if (message.sfixed64Field != null && Object.hasOwnProperty.call(message, "sfixed64Field"))
+                writer.uint32(113).sfixed64(message.sfixed64Field);
             return writer;
         };
 
@@ -819,6 +875,18 @@ export const typeTest3 = $root.typeTest3 = (() => {
                     break;
                 case 10:
                     message.bytesField = reader.bytes();
+                    break;
+                case 11:
+                    message.uint64Field = reader.uint64();
+                    break;
+                case 12:
+                    message.sint64Field = reader.sint64();
+                    break;
+                case 13:
+                    message.fixed64Field = reader.fixed64();
+                    break;
+                case 14:
+                    message.sfixed64Field = reader.sfixed64();
                     break;
                 default:
                     reader.skipType(tag & 7);

--- a/packages/bs-protobuf/test/proto-res/Proto.proto.js
+++ b/packages/bs-protobuf/test/proto-res/Proto.proto.js
@@ -433,6 +433,10 @@ export const typeTest = $root.typeTest = (() => {
         Typeful.prototype.sint64Field = $util.Long ? $util.Long.fromBits(0,0,true) : 0;
         Typeful.prototype.fixed64Field = $util.Long ? $util.Long.fromBits(0,0,true) : 0;
         Typeful.prototype.sfixed64Field = $util.Long ? $util.Long.fromBits(0,0,true) : 0;
+        Typeful.prototype.uint32Field = 0;
+        Typeful.prototype.sint32Field = 0;
+        Typeful.prototype.fixed32Field = 0;
+        Typeful.prototype.sfixed32Field = 0;
 
         let $oneOfFields;
 
@@ -477,6 +481,14 @@ export const typeTest = $root.typeTest = (() => {
                 writer.uint32(104).uint64(message.fixed64Field);
             if (message.sfixed64Field != null && Object.hasOwnProperty.call(message, "sfixed64Field"))
                 writer.uint32(112).uint64(message.sfixed64Field);
+            if (message.uint32Field != null && Object.hasOwnProperty.call(message, "uint32Field"))
+                writer.uint32(120).uint32(message.uint32Field);
+            if (message.sint32Field != null && Object.hasOwnProperty.call(message, "sint32Field"))
+                writer.uint32(128).sint32(message.sint32Field);
+            if (message.fixed32Field != null && Object.hasOwnProperty.call(message, "fixed32Field"))
+                writer.uint32(141).fixed32(message.fixed32Field);
+            if (message.sfixed32Field != null && Object.hasOwnProperty.call(message, "sfixed32Field"))
+                writer.uint32(149).sfixed32(message.sfixed32Field);
             return writer;
         };
 
@@ -534,6 +546,18 @@ export const typeTest = $root.typeTest = (() => {
                     break;
                 case 14:
                     message.sfixed64Field = reader.uint64();
+                    break;
+                case 15:
+                    message.uint32Field = reader.uint32();
+                    break;
+                case 16:
+                    message.sint32Field = reader.sint32();
+                    break;
+                case 17:
+                    message.fixed32Field = reader.fixed32();
+                    break;
+                case 18:
+                    message.sfixed32Field = reader.sfixed32();
                     break;
                 default:
                     reader.skipType(tag & 7);
@@ -731,6 +755,10 @@ export const typeTest3 = $root.typeTest3 = (() => {
         Typeful.prototype.sint64Field = null;
         Typeful.prototype.fixed64Field = null;
         Typeful.prototype.sfixed64Field = null;
+        Typeful.prototype.uint32Field = null;
+        Typeful.prototype.sint32Field = null;
+        Typeful.prototype.fixed32Field = null;
+        Typeful.prototype.sfixed32Field = null;
 
         let $oneOfFields;
 
@@ -794,6 +822,26 @@ export const typeTest3 = $root.typeTest3 = (() => {
             set: $util.oneOfSetter($oneOfFields)
         });
 
+        Object.defineProperty(Typeful.prototype, "_uint32Field", {
+            get: $util.oneOfGetter($oneOfFields = ["uint32Field"]),
+            set: $util.oneOfSetter($oneOfFields)
+        });
+
+        Object.defineProperty(Typeful.prototype, "_sint32Field", {
+            get: $util.oneOfGetter($oneOfFields = ["sint32Field"]),
+            set: $util.oneOfSetter($oneOfFields)
+        });
+
+        Object.defineProperty(Typeful.prototype, "_fixed32Field", {
+            get: $util.oneOfGetter($oneOfFields = ["fixed32Field"]),
+            set: $util.oneOfSetter($oneOfFields)
+        });
+
+        Object.defineProperty(Typeful.prototype, "_sfixed32Field", {
+            get: $util.oneOfGetter($oneOfFields = ["sfixed32Field"]),
+            set: $util.oneOfSetter($oneOfFields)
+        });
+
         Typeful.create = function create(properties) {
             return new Typeful(properties);
         };
@@ -830,6 +878,14 @@ export const typeTest3 = $root.typeTest3 = (() => {
                 writer.uint32(105).fixed64(message.fixed64Field);
             if (message.sfixed64Field != null && Object.hasOwnProperty.call(message, "sfixed64Field"))
                 writer.uint32(113).sfixed64(message.sfixed64Field);
+            if (message.uint32Field != null && Object.hasOwnProperty.call(message, "uint32Field"))
+                writer.uint32(120).uint32(message.uint32Field);
+            if (message.sint32Field != null && Object.hasOwnProperty.call(message, "sint32Field"))
+                writer.uint32(128).sint32(message.sint32Field);
+            if (message.fixed32Field != null && Object.hasOwnProperty.call(message, "fixed32Field"))
+                writer.uint32(141).fixed32(message.fixed32Field);
+            if (message.sfixed32Field != null && Object.hasOwnProperty.call(message, "sfixed32Field"))
+                writer.uint32(149).sfixed32(message.sfixed32Field);
             return writer;
         };
 
@@ -887,6 +943,18 @@ export const typeTest3 = $root.typeTest3 = (() => {
                     break;
                 case 14:
                     message.sfixed64Field = reader.sfixed64();
+                    break;
+                case 15:
+                    message.uint32Field = reader.uint32();
+                    break;
+                case 16:
+                    message.sint32Field = reader.sint32();
+                    break;
+                case 17:
+                    message.fixed32Field = reader.fixed32();
+                    break;
+                case 18:
+                    message.sfixed32Field = reader.sfixed32();
                     break;
                 default:
                     reader.skipType(tag & 7);

--- a/packages/bs-protobuf/test/proto-res/Proto.res
+++ b/packages/bs-protobuf/test/proto-res/Proto.res
@@ -182,9 +182,13 @@ module TypeTest = {
       @as("sint64Field") sint64Field: int64,
       @as("fixed64Field") fixed64Field: int64,
       @as("sfixed64Field") sfixed64Field: int64,
+      @as("uint32Field") uint32Field: int,
+      @as("sint32Field") sint32Field: int,
+      @as("fixed32Field") fixed32Field: int,
+      @as("sfixed32Field") sfixed32Field: int,
       @as("valueField") valueField: Oneof.ValueField.t,
     }
-    let make = (~stringField="", ~int32Field=0, ~int64Field=Int64.of_string("0"), ~enumField=EnumType.EnumV0, ~enumEField=EnumTypeE.EnumVE0, ~basicField=Basic.make(), ~repeatedStringField=[], ~bytesField=Js_typed_array.Uint8Array.make([]), ~uint64Field=Int64.of_string("0"), ~sint64Field=Int64.of_string("0"), ~fixed64Field=Int64.of_string("0"), ~sfixed64Field=Int64.of_string("0"), ~valueField=Oneof.ValueField.None, ()) => {stringField: stringField, int32Field: int32Field, int64Field: int64Field, enumField: enumField, enumEField: enumEField, basicField: basicField, repeatedStringField: repeatedStringField, bytesField: bytesField, uint64Field: uint64Field, sint64Field: sint64Field, fixed64Field: fixed64Field, sfixed64Field: sfixed64Field, valueField: valueField, }
+    let make = (~stringField="", ~int32Field=0, ~int64Field=Int64.of_string("0"), ~enumField=EnumType.EnumV0, ~enumEField=EnumTypeE.EnumVE0, ~basicField=Basic.make(), ~repeatedStringField=[], ~bytesField=Js_typed_array.Uint8Array.make([]), ~uint64Field=Int64.of_string("0"), ~sint64Field=Int64.of_string("0"), ~fixed64Field=Int64.of_string("0"), ~sfixed64Field=Int64.of_string("0"), ~uint32Field=0, ~sint32Field=0, ~fixed32Field=0, ~sfixed32Field=0, ~valueField=Oneof.ValueField.None, ()) => {stringField: stringField, int32Field: int32Field, int64Field: int64Field, enumField: enumField, enumEField: enumEField, basicField: basicField, repeatedStringField: repeatedStringField, bytesField: bytesField, uint64Field: uint64Field, sint64Field: sint64Field, fixed64Field: fixed64Field, sfixed64Field: sfixed64Field, uint32Field: uint32Field, sint32Field: sint32Field, fixed32Field: fixed32Field, sfixed32Field: sfixed32Field, valueField: valueField, }
     @module("./Proto.proto.js") @val @scope("typeTest") external messageClass: _ = "Typeful"
     let encode = v => {
       Js.Obj.empty()
@@ -200,6 +204,10 @@ module TypeTest = {
       ->ReprotoBsProtobuf.ProtoTypeSupport.Field.fromR("sint64Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.uint64, v)
       ->ReprotoBsProtobuf.ProtoTypeSupport.Field.fromR("fixed64Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.uint64, v)
       ->ReprotoBsProtobuf.ProtoTypeSupport.Field.fromR("sfixed64Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.uint64, v)
+      ->ReprotoBsProtobuf.ProtoTypeSupport.Field.fromR("uint32Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.uint32, v)
+      ->ReprotoBsProtobuf.ProtoTypeSupport.Field.fromR("sint32Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.sint32, v)
+      ->ReprotoBsProtobuf.ProtoTypeSupport.Field.fromR("fixed32Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.fixed32, v)
+      ->ReprotoBsProtobuf.ProtoTypeSupport.Field.fromR("sfixed32Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.sfixed32, v)
       ->ReprotoBsProtobuf.ProtoTypeSupport.Field.fromR("valueField", Oneof.ValueField.convert, v)
       ->ReprotoBsProtobuf.ProtoTypeSupport.encode(messageClass)
     }
@@ -218,6 +226,10 @@ module TypeTest = {
       ->ReprotoBsProtobuf.ProtoTypeSupport.Field.toR("sint64Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.uint64, m)
       ->ReprotoBsProtobuf.ProtoTypeSupport.Field.toR("fixed64Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.uint64, m)
       ->ReprotoBsProtobuf.ProtoTypeSupport.Field.toR("sfixed64Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.uint64, m)
+      ->ReprotoBsProtobuf.ProtoTypeSupport.Field.toR("uint32Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.uint32, m)
+      ->ReprotoBsProtobuf.ProtoTypeSupport.Field.toR("sint32Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.sint32, m)
+      ->ReprotoBsProtobuf.ProtoTypeSupport.Field.toR("fixed32Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.fixed32, m)
+      ->ReprotoBsProtobuf.ProtoTypeSupport.Field.toR("sfixed32Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.sfixed32, m)
       ->ReprotoBsProtobuf.ProtoTypeSupport.Field.toR("valueField", Oneof.ValueField.convert, m)
     }
   }
@@ -301,9 +313,13 @@ module TypeTest3 = {
       @as("sint64Field") sint64Field: option<int64>,
       @as("fixed64Field") fixed64Field: option<int64>,
       @as("sfixed64Field") sfixed64Field: option<int64>,
+      @as("uint32Field") uint32Field: option<int>,
+      @as("sint32Field") sint32Field: option<int>,
+      @as("fixed32Field") fixed32Field: option<int>,
+      @as("sfixed32Field") sfixed32Field: option<int>,
       @as("valueField") valueField: Oneof.ValueField.t,
     }
-    let make = (~stringField=None, ~int32Field=None, ~int64Field=None, ~enumField=None, ~enumEField=None, ~basicField=None, ~repeatedStringField=[], ~bytesField=None, ~uint64Field=None, ~sint64Field=None, ~fixed64Field=None, ~sfixed64Field=None, ~valueField=Oneof.ValueField.None, ()) => {stringField: stringField, int32Field: int32Field, int64Field: int64Field, enumField: enumField, enumEField: enumEField, basicField: basicField, repeatedStringField: repeatedStringField, bytesField: bytesField, uint64Field: uint64Field, sint64Field: sint64Field, fixed64Field: fixed64Field, sfixed64Field: sfixed64Field, valueField: valueField, }
+    let make = (~stringField=None, ~int32Field=None, ~int64Field=None, ~enumField=None, ~enumEField=None, ~basicField=None, ~repeatedStringField=[], ~bytesField=None, ~uint64Field=None, ~sint64Field=None, ~fixed64Field=None, ~sfixed64Field=None, ~uint32Field=None, ~sint32Field=None, ~fixed32Field=None, ~sfixed32Field=None, ~valueField=Oneof.ValueField.None, ()) => {stringField: stringField, int32Field: int32Field, int64Field: int64Field, enumField: enumField, enumEField: enumEField, basicField: basicField, repeatedStringField: repeatedStringField, bytesField: bytesField, uint64Field: uint64Field, sint64Field: sint64Field, fixed64Field: fixed64Field, sfixed64Field: sfixed64Field, uint32Field: uint32Field, sint32Field: sint32Field, fixed32Field: fixed32Field, sfixed32Field: sfixed32Field, valueField: valueField, }
     @module("./Proto.proto.js") @val @scope("typeTest3") external messageClass: _ = "Typeful"
     let encode = v => {
       Js.Obj.empty()
@@ -319,6 +335,10 @@ module TypeTest3 = {
       ->ReprotoBsProtobuf.ProtoTypeSupport.Field.fromR("sint64Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.sint64, v)
       ->ReprotoBsProtobuf.ProtoTypeSupport.Field.fromR("fixed64Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.fixed64, v)
       ->ReprotoBsProtobuf.ProtoTypeSupport.Field.fromR("sfixed64Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.sfixed64, v)
+      ->ReprotoBsProtobuf.ProtoTypeSupport.Field.fromR("uint32Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.uint32, v)
+      ->ReprotoBsProtobuf.ProtoTypeSupport.Field.fromR("sint32Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.sint32, v)
+      ->ReprotoBsProtobuf.ProtoTypeSupport.Field.fromR("fixed32Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.fixed32, v)
+      ->ReprotoBsProtobuf.ProtoTypeSupport.Field.fromR("sfixed32Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.sfixed32, v)
       ->ReprotoBsProtobuf.ProtoTypeSupport.Field.fromR("valueField", Oneof.ValueField.convert, v)
       ->ReprotoBsProtobuf.ProtoTypeSupport.encode(messageClass)
     }
@@ -337,6 +357,10 @@ module TypeTest3 = {
       ->ReprotoBsProtobuf.ProtoTypeSupport.Field.toR("sint64Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.sint64, m)
       ->ReprotoBsProtobuf.ProtoTypeSupport.Field.toR("fixed64Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.fixed64, m)
       ->ReprotoBsProtobuf.ProtoTypeSupport.Field.toR("sfixed64Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.sfixed64, m)
+      ->ReprotoBsProtobuf.ProtoTypeSupport.Field.toR("uint32Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.uint32, m)
+      ->ReprotoBsProtobuf.ProtoTypeSupport.Field.toR("sint32Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.sint32, m)
+      ->ReprotoBsProtobuf.ProtoTypeSupport.Field.toR("fixed32Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.fixed32, m)
+      ->ReprotoBsProtobuf.ProtoTypeSupport.Field.toR("sfixed32Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.sfixed32, m)
       ->ReprotoBsProtobuf.ProtoTypeSupport.Field.toR("valueField", Oneof.ValueField.convert, m)
     }
   }

--- a/packages/bs-protobuf/test/proto-res/Proto.res
+++ b/packages/bs-protobuf/test/proto-res/Proto.res
@@ -178,9 +178,13 @@ module TypeTest = {
       @as("basicField") basicField: Basic.t,
       @as("repeatedStringField") repeatedStringField: array<string>,
       @as("bytesField") bytesField: Js_typed_array.Uint8Array.t,
+      @as("uint64Field") uint64Field: int64,
+      @as("sint64Field") sint64Field: int64,
+      @as("fixed64Field") fixed64Field: int64,
+      @as("sfixed64Field") sfixed64Field: int64,
       @as("valueField") valueField: Oneof.ValueField.t,
     }
-    let make = (~stringField="", ~int32Field=0, ~int64Field=Int64.of_string("0"), ~enumField=EnumType.EnumV0, ~enumEField=EnumTypeE.EnumVE0, ~basicField=Basic.make(), ~repeatedStringField=[], ~bytesField=Js_typed_array.Uint8Array.make([]), ~valueField=Oneof.ValueField.None, ()) => {stringField: stringField, int32Field: int32Field, int64Field: int64Field, enumField: enumField, enumEField: enumEField, basicField: basicField, repeatedStringField: repeatedStringField, bytesField: bytesField, valueField: valueField, }
+    let make = (~stringField="", ~int32Field=0, ~int64Field=Int64.of_string("0"), ~enumField=EnumType.EnumV0, ~enumEField=EnumTypeE.EnumVE0, ~basicField=Basic.make(), ~repeatedStringField=[], ~bytesField=Js_typed_array.Uint8Array.make([]), ~uint64Field=Int64.of_string("0"), ~sint64Field=Int64.of_string("0"), ~fixed64Field=Int64.of_string("0"), ~sfixed64Field=Int64.of_string("0"), ~valueField=Oneof.ValueField.None, ()) => {stringField: stringField, int32Field: int32Field, int64Field: int64Field, enumField: enumField, enumEField: enumEField, basicField: basicField, repeatedStringField: repeatedStringField, bytesField: bytesField, uint64Field: uint64Field, sint64Field: sint64Field, fixed64Field: fixed64Field, sfixed64Field: sfixed64Field, valueField: valueField, }
     @module("./Proto.proto.js") @val @scope("typeTest") external messageClass: _ = "Typeful"
     let encode = v => {
       Js.Obj.empty()
@@ -192,6 +196,10 @@ module TypeTest = {
       ->ReprotoBsProtobuf.ProtoTypeSupport.Field.fromR("basicField", ReprotoBsProtobuf.ProtoTypeSupport.Convert.message, v)
       ->ReprotoBsProtobuf.ProtoTypeSupport.MapField.fromR("repeatedStringField", ReprotoBsProtobuf.ProtoTypeSupport.Convert.string, v)
       ->ReprotoBsProtobuf.ProtoTypeSupport.Field.fromR("bytesField", ReprotoBsProtobuf.ProtoTypeSupport.Convert.bytes, v)
+      ->ReprotoBsProtobuf.ProtoTypeSupport.Field.fromR("uint64Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.uint64, v)
+      ->ReprotoBsProtobuf.ProtoTypeSupport.Field.fromR("sint64Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.uint64, v)
+      ->ReprotoBsProtobuf.ProtoTypeSupport.Field.fromR("fixed64Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.uint64, v)
+      ->ReprotoBsProtobuf.ProtoTypeSupport.Field.fromR("sfixed64Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.uint64, v)
       ->ReprotoBsProtobuf.ProtoTypeSupport.Field.fromR("valueField", Oneof.ValueField.convert, v)
       ->ReprotoBsProtobuf.ProtoTypeSupport.encode(messageClass)
     }
@@ -206,6 +214,10 @@ module TypeTest = {
       ->ReprotoBsProtobuf.ProtoTypeSupport.Field.toR("basicField", ReprotoBsProtobuf.ProtoTypeSupport.Convert.message, m)
       ->ReprotoBsProtobuf.ProtoTypeSupport.MapField.toR("repeatedStringField", ReprotoBsProtobuf.ProtoTypeSupport.Convert.string, m)
       ->ReprotoBsProtobuf.ProtoTypeSupport.Field.toR("bytesField", ReprotoBsProtobuf.ProtoTypeSupport.Convert.bytes, m)
+      ->ReprotoBsProtobuf.ProtoTypeSupport.Field.toR("uint64Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.uint64, m)
+      ->ReprotoBsProtobuf.ProtoTypeSupport.Field.toR("sint64Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.uint64, m)
+      ->ReprotoBsProtobuf.ProtoTypeSupport.Field.toR("fixed64Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.uint64, m)
+      ->ReprotoBsProtobuf.ProtoTypeSupport.Field.toR("sfixed64Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.uint64, m)
       ->ReprotoBsProtobuf.ProtoTypeSupport.Field.toR("valueField", Oneof.ValueField.convert, m)
     }
   }
@@ -285,9 +297,13 @@ module TypeTest3 = {
       @as("basicField") basicField: option<Basic.t>,
       @as("repeatedStringField") repeatedStringField: array<string>,
       @as("bytesField") bytesField: option<Js_typed_array.Uint8Array.t>,
+      @as("uint64Field") uint64Field: option<int64>,
+      @as("sint64Field") sint64Field: option<int64>,
+      @as("fixed64Field") fixed64Field: option<int64>,
+      @as("sfixed64Field") sfixed64Field: option<int64>,
       @as("valueField") valueField: Oneof.ValueField.t,
     }
-    let make = (~stringField=None, ~int32Field=None, ~int64Field=None, ~enumField=None, ~enumEField=None, ~basicField=None, ~repeatedStringField=[], ~bytesField=None, ~valueField=Oneof.ValueField.None, ()) => {stringField: stringField, int32Field: int32Field, int64Field: int64Field, enumField: enumField, enumEField: enumEField, basicField: basicField, repeatedStringField: repeatedStringField, bytesField: bytesField, valueField: valueField, }
+    let make = (~stringField=None, ~int32Field=None, ~int64Field=None, ~enumField=None, ~enumEField=None, ~basicField=None, ~repeatedStringField=[], ~bytesField=None, ~uint64Field=None, ~sint64Field=None, ~fixed64Field=None, ~sfixed64Field=None, ~valueField=Oneof.ValueField.None, ()) => {stringField: stringField, int32Field: int32Field, int64Field: int64Field, enumField: enumField, enumEField: enumEField, basicField: basicField, repeatedStringField: repeatedStringField, bytesField: bytesField, uint64Field: uint64Field, sint64Field: sint64Field, fixed64Field: fixed64Field, sfixed64Field: sfixed64Field, valueField: valueField, }
     @module("./Proto.proto.js") @val @scope("typeTest3") external messageClass: _ = "Typeful"
     let encode = v => {
       Js.Obj.empty()
@@ -299,6 +315,10 @@ module TypeTest3 = {
       ->ReprotoBsProtobuf.ProtoTypeSupport.Field.fromR("basicField", ReprotoBsProtobuf.ProtoTypeSupport.Convert.message, v)
       ->ReprotoBsProtobuf.ProtoTypeSupport.MapField.fromR("repeatedStringField", ReprotoBsProtobuf.ProtoTypeSupport.Convert.string, v)
       ->ReprotoBsProtobuf.ProtoTypeSupport.Field.fromR("bytesField", ReprotoBsProtobuf.ProtoTypeSupport.Convert.bytes, v)
+      ->ReprotoBsProtobuf.ProtoTypeSupport.Field.fromR("uint64Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.uint64, v)
+      ->ReprotoBsProtobuf.ProtoTypeSupport.Field.fromR("sint64Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.sint64, v)
+      ->ReprotoBsProtobuf.ProtoTypeSupport.Field.fromR("fixed64Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.fixed64, v)
+      ->ReprotoBsProtobuf.ProtoTypeSupport.Field.fromR("sfixed64Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.sfixed64, v)
       ->ReprotoBsProtobuf.ProtoTypeSupport.Field.fromR("valueField", Oneof.ValueField.convert, v)
       ->ReprotoBsProtobuf.ProtoTypeSupport.encode(messageClass)
     }
@@ -313,6 +333,10 @@ module TypeTest3 = {
       ->ReprotoBsProtobuf.ProtoTypeSupport.Field.toR("basicField", ReprotoBsProtobuf.ProtoTypeSupport.Convert.message, m)
       ->ReprotoBsProtobuf.ProtoTypeSupport.MapField.toR("repeatedStringField", ReprotoBsProtobuf.ProtoTypeSupport.Convert.string, m)
       ->ReprotoBsProtobuf.ProtoTypeSupport.Field.toR("bytesField", ReprotoBsProtobuf.ProtoTypeSupport.Convert.bytes, m)
+      ->ReprotoBsProtobuf.ProtoTypeSupport.Field.toR("uint64Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.uint64, m)
+      ->ReprotoBsProtobuf.ProtoTypeSupport.Field.toR("sint64Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.sint64, m)
+      ->ReprotoBsProtobuf.ProtoTypeSupport.Field.toR("fixed64Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.fixed64, m)
+      ->ReprotoBsProtobuf.ProtoTypeSupport.Field.toR("sfixed64Field", ReprotoBsProtobuf.ProtoTypeSupport.Convert.sfixed64, m)
       ->ReprotoBsProtobuf.ProtoTypeSupport.Field.toR("valueField", Oneof.ValueField.convert, m)
     }
   }

--- a/packages/bs-protobuf/test/proto/type_test.proto
+++ b/packages/bs-protobuf/test/proto/type_test.proto
@@ -37,4 +37,8 @@ message Typeful {
   }
   repeated string repeatedStringField=9;
   optional bytes bytesField=10;
+  optional uint64 uint64Field=11;
+  optional uint64 sint64Field=12;
+  optional uint64 fixed64Field=13;
+  optional uint64 sfixed64Field=14;
 }

--- a/packages/bs-protobuf/test/proto/type_test.proto
+++ b/packages/bs-protobuf/test/proto/type_test.proto
@@ -41,4 +41,8 @@ message Typeful {
   optional uint64 sint64Field=12;
   optional uint64 fixed64Field=13;
   optional uint64 sfixed64Field=14;
+  optional uint32 uint32Field=15;
+  optional sint32 sint32Field=16;
+  optional fixed32 fixed32Field=17;
+  optional sfixed32 sfixed32Field=18;
 }

--- a/packages/bs-protobuf/test/proto/type_test_3.proto
+++ b/packages/bs-protobuf/test/proto/type_test_3.proto
@@ -41,4 +41,8 @@ message Typeful {
   optional sint64 sint64Field=12;
   optional fixed64 fixed64Field=13;
   optional sfixed64 sfixed64Field=14;
+  optional uint32 uint32Field=15;
+  optional sint32 sint32Field=16;
+  optional fixed32 fixed32Field=17;
+  optional sfixed32 sfixed32Field=18;
 }

--- a/packages/bs-protobuf/test/proto/type_test_3.proto
+++ b/packages/bs-protobuf/test/proto/type_test_3.proto
@@ -37,4 +37,8 @@ message Typeful {
   }
   repeated string repeatedStringField=9;
   optional bytes bytesField=10;
+  optional uint64 uint64Field=11;
+  optional sint64 sint64Field=12;
+  optional fixed64 fixed64Field=13;
+  optional sfixed64 sfixed64Field=14;
 }


### PR DESCRIPTION
- protores compilation fixes
  * improve error handling of proto compilation, do not crash on error
  * add protores:dev yarn command target
- remove unneeded code
- add field types
  * uint64
  * sint64
  * fixed64
  * sfixed64
  * uint32
  * sint32
  * fixed32
  * sfixed32
- support unsigned types
  * support 64 bit types with overflow style
  * ensure to return safe values with 32 bit types, overflow correcly with negatives
- refactor type mapping support
- refactor type tests