### PR TITLE
Fix message types with no fields to work

### DIFF
--- a/packages/bs-protobuf/test/__tests__/FieldTypes3_test.res
+++ b/packages/bs-protobuf/test/__tests__/FieldTypes3_test.res
@@ -447,4 +447,20 @@ describe("Protobuf field types support", () => {
       })
     })
   })
+
+  describe("empty", () => {
+    let testTypeSupport = (v: Empty.t) => {
+      test("encode/decode", () => v |> Empty.encode |> Empty.decode |> expect |> toEqual(v))
+    }
+    describe("make", () => Empty.make()->testTypeSupport)
+    describe("as unit", () => ()->testTypeSupport)
+
+    describe("defaults", () => {
+      let v = Empty.make()
+      test("encode empty", () =>
+        v |> Empty.encode |> Js_typed_array.ArrayBuffer.byteLength |> expect |> toBe(0)
+      )
+      test("encode/decode", () => v |> Empty.encode |> Empty.decode |> expect |> toEqual(v))
+    })
+  })
 })

--- a/packages/bs-protobuf/test/__tests__/FieldTypes_test.res
+++ b/packages/bs-protobuf/test/__tests__/FieldTypes_test.res
@@ -494,4 +494,20 @@ describe("Protobuf field types support", () => {
       })
     })
   })
+
+  describe("empty", () => {
+    let testTypeSupport = (v: Empty.t) => {
+      test("encode/decode", () => v |> Empty.encode |> Empty.decode |> expect |> toEqual(v))
+    }
+    describe("make", () => Empty.make()->testTypeSupport)
+    describe("as unit", () => ()->testTypeSupport)
+
+    describe("defaults", () => {
+      let v = Empty.make()
+      test("encode empty", () =>
+        v |> Empty.encode |> Js_typed_array.ArrayBuffer.byteLength |> expect |> toBe(0)
+      )
+      test("encode/decode", () => v |> Empty.encode |> Empty.decode |> expect |> toEqual(v))
+    })
+  })
 })

--- a/packages/bs-protobuf/test/proto/type_test.proto
+++ b/packages/bs-protobuf/test/proto/type_test.proto
@@ -56,3 +56,6 @@ message Typeful {
   map<bool, string> mapBoolStringField=25;
   optional google.protobuf.Any anyField=26;
 }
+
+message Empty {
+}

--- a/packages/bs-protobuf/test/proto/type_test_3.proto
+++ b/packages/bs-protobuf/test/proto/type_test_3.proto
@@ -54,3 +54,6 @@ message Typeful {
   map<bool, string> mapBoolStringField=25;
   google.protobuf.Any anyField=26;
 }
+
+message Empty {
+}


### PR DESCRIPTION
Although an edge case, this must work as well. Empty messages will be
reprerented as unit internally.