### PR TITLE
Fix support for capitalized field names

### DIFF
--- a/packages/bs-protobuf/src/compiler/gen-types/emit-pass1.js
+++ b/packages/bs-protobuf/src/compiler/gen-types/emit-pass1.js
@@ -244,16 +244,16 @@ ${" ".repeat(indent)}  type t = {
     for (const fieldName of iterRealFieldNames(resolver)) {
       const field = data.fields[fieldName];
       stream.write(`\
-${" ".repeat(indent)}    @as("${decapitalize(fieldName)}") ${fieldName}: ${
+${" ".repeat(indent)}    @as("${fieldName}") ${decapitalize(fieldName)}: ${
         mapFieldType(field, resolver).name
       },
 `);
     }
     for (const fieldName of iterOneofFieldNames(resolver)) {
       stream.write(`\
-${" ".repeat(indent)}    @as("${decapitalize(
+${" ".repeat(indent)}    @as("${fieldName}") ${decapitalize(
         fieldName
-      )}") ${fieldName}: Oneof.${capitalize(fieldName)}.t,
+      )}: Oneof.${capitalize(fieldName)}.t,
 `);
     }
     stream.write(`\
@@ -293,18 +293,18 @@ ${" ".repeat(indent)}    Js.Obj.empty()
       stream.write(`\
 ${" ".repeat(indent)}    ->${bsProtobufPackage}.ProtoTypeSupport.${
         mapper.fieldAccessor
-      }.fromR("${decapitalize(
-        fieldName
-      )}", ${bsProtobufPackage}.ProtoTypeSupport.Convert.${mapper.type}, v)
+      }.fromR("${fieldName}", ${bsProtobufPackage}.ProtoTypeSupport.Convert.${
+        mapper.type
+      }, v)
 `);
     }
     for (const fieldName of iterOneofFieldNames(resolver)) {
       stream.write(`\
 ${" ".repeat(
   indent
-)}    ->${bsProtobufPackage}.ProtoTypeSupport.Field.fromR("${decapitalize(
+)}    ->${bsProtobufPackage}.ProtoTypeSupport.Field.fromR("${fieldName}", Oneof.${capitalize(
         fieldName
-      )}", Oneof.${capitalize(fieldName)}.convert, v)
+      )}.convert, v)
 `);
     }
     // ${" ".repeat(
@@ -327,18 +327,18 @@ ${" ".repeat(indent)}    make()
       stream.write(`\
 ${" ".repeat(indent)}    ->${bsProtobufPackage}.ProtoTypeSupport.${
         mapper.fieldAccessor
-      }.toR("${decapitalize(
-        fieldName
-      )}", ${bsProtobufPackage}.ProtoTypeSupport.Convert.${mapper.type}, m)
+      }.toR("${fieldName}", ${bsProtobufPackage}.ProtoTypeSupport.Convert.${
+        mapper.type
+      }, m)
 `);
     }
     for (const fieldName of iterOneofFieldNames(resolver)) {
       stream.write(`\
 ${" ".repeat(
   indent
-)}    ->${bsProtobufPackage}.ProtoTypeSupport.Field.toR("${decapitalize(
+)}    ->${bsProtobufPackage}.ProtoTypeSupport.Field.toR("${fieldName}", Oneof.${capitalize(
         fieldName
-      )}", Oneof.${capitalize(fieldName)}.convert, m)
+      )}.convert, m)
 `);
     }
   }

--- a/packages/bs-protobuf/test/__tests__/FieldTypes3_test.res
+++ b/packages/bs-protobuf/test/__tests__/FieldTypes3_test.res
@@ -65,6 +65,44 @@ describe("Protobuf field types support", () => {
     })
   })
 
+  describe("capitalization", () => {
+    let testTypeSupport = (v: Capitalization.t) => {
+      test("string", () => v.stringField |> expect |> toBe(Some("The answer")))
+      test("int32", () => v.int32Field |> expect |> toBe(Some(42)))
+      // test("verify", () => v |> Capitalization.verify |> expect |> toBe(None))
+      test("encode/decode", () =>
+        v |> Capitalization.encode |> Capitalization.decode |> expect |> toEqual(v)
+      )
+    }
+
+    Only.describe("make", () =>
+      Capitalization.make(
+        ~stringField=Some("The answer"),
+        ~int32Field=Some(42),
+        (),
+      )->testTypeSupport
+    )
+
+    describe("as record", () =>
+      {
+        stringField: Some("The answer"),
+        int32Field: Some(42),
+      }->testTypeSupport
+    )
+
+    describe("defaults", () => {
+      let v = Capitalization.make()
+      test("string", () => v.stringField |> expect |> toBe(None))
+      test("int32", () => v.int32Field |> expect |> toBe(None))
+      test("encode empty", () =>
+        v |> Capitalization.encode |> Js_typed_array.ArrayBuffer.byteLength |> expect |> toBe(0)
+      )
+      test("encode/decode", () =>
+        v |> Capitalization.encode |> Capitalization.decode |> expect |> toEqual(v)
+      )
+    })
+  })
+
   describe("typeful", () => {
     describe("string", () => {
       let v = Typeful.make(~stringField=Some("The answer"), ())

--- a/packages/bs-protobuf/test/__tests__/FieldTypes_test.res
+++ b/packages/bs-protobuf/test/__tests__/FieldTypes_test.res
@@ -65,6 +65,40 @@ describe("Protobuf field types support", () => {
     })
   })
 
+  describe("capitalization", () => {
+    let testTypeSupport = (v: Capitalization.t) => {
+      test("string", () => v.stringField |> expect |> toBe("The answer"))
+      test("int32", () => v.int32Field |> expect |> toBe(42))
+      // test("verify", () => v |> Capitalization.verify |> expect |> toBe(None))
+      test("encode/decode", () =>
+        v |> Capitalization.encode |> Capitalization.decode |> expect |> toEqual(v)
+      )
+    }
+
+    describe("make", () =>
+      Capitalization.make(~stringField="The answer", ~int32Field=42, ())->testTypeSupport
+    )
+
+    describe("as record", () =>
+      {
+        stringField: "The answer",
+        int32Field: 42,
+      }->testTypeSupport
+    )
+
+    describe("defaults", () => {
+      let v = Capitalization.make()
+      test("string", () => v.stringField |> expect |> toBe(""))
+      test("int32", () => v.int32Field |> expect |> toBe(0))
+      test("encode empty", () =>
+        v |> Capitalization.encode |> Js_typed_array.ArrayBuffer.byteLength |> expect |> toBe(4)
+      )
+      test("encode/decode", () =>
+        v |> Capitalization.encode |> Capitalization.decode |> expect |> toEqual(v)
+      )
+    })
+  })
+
   describe("typeful", () => {
     describe("string", () => {
       let v = Typeful.make(~stringField="The answer", ())

--- a/packages/bs-protobuf/test/proto/type_test.proto
+++ b/packages/bs-protobuf/test/proto/type_test.proto
@@ -15,6 +15,11 @@ message Required {
   required int32 int32Field = 2;
 }
 
+message Capitalization {
+  optional string StringField = 1;
+  optional int32 Int32Field = 2;
+}
+
 enum EnumType {
   EnumV0 = 0;
   EnumV1 = 1;

--- a/packages/bs-protobuf/test/proto/type_test_3.proto
+++ b/packages/bs-protobuf/test/proto/type_test_3.proto
@@ -13,6 +13,11 @@ message Required {
   int32 int32Field = 2;
 }
 
+message Capitalization {
+  optional string StringField = 1;
+  optional int32 Int32Field = 2;
+}
+
 enum EnumType {
   EnumV0 = 0;
   EnumV1 = 1;


### PR DESCRIPTION
Remark: in consistence with the other language implementation, no
provision is provided to support multiple capitalized versions within
the same message class. Ie. defining field names "aType" and "AType"
within the same message class is unsupported, and will cause an error
in Rescript.