### PR TITLE
Implement outer resolution of dot entity references

### DIFF
--- a/packages/bs-protobuf/src/compiler/gen-types/__tests__/resolver-test.js
+++ b/packages/bs-protobuf/src/compiler/gen-types/__tests__/resolver-test.js
@@ -180,6 +180,56 @@ describe("gen-types Resolver", () => {
         expect(resolver3.chain.chain.chain).toBe(resolver);
         expect(resolver3.relativePath).toEqual("Delta.Epsilon");
       });
+
+      test("inner", () => {
+        const resolver = new Resolver(
+          {
+            nested: {
+              alpha: {
+                nested: {
+                  beta: { nested: { gamma: "{GAMMA}" } },
+                  delta: { nested: { epsilon: "{EPSILON-INNER}" } },
+                },
+              },
+              delta: { nested: { epsilon: "{EPSILON-OUTER}" } },
+            },
+          },
+          "PROTO_JS_PATH"
+        );
+        const resolver1 = resolver.next("alpha").next("beta").next("gamma");
+        const resolver2 = resolver1.lookup("delta");
+        expect(resolver2.data).toEqual({
+          nested: { epsilon: "{EPSILON-INNER}" },
+        });
+        const resolver3 = resolver1.lookup("delta.epsilon");
+        expect(resolver3.data).toBe("{EPSILON-INNER}");
+      });
+
+      test("outer", () => {
+        const resolver = new Resolver(
+          {
+            nested: {
+              alpha: {
+                nested: {
+                  beta: { nested: { gamma: "{GAMMA}" } },
+                  delta: { nested: { epsilon: "{EPSILON-INNER}" } },
+                },
+              },
+              delta: { nested: { epsilon: "{EPSILON-OUTER}" } },
+            },
+          },
+          "PROTO_JS_PATH"
+        );
+        const resolver1 = resolver.next("alpha").next("beta").next("gamma");
+        // dot prefix looks up from the root
+        const resolver2 = resolver1.lookup(".delta");
+        expect(resolver2.data).toEqual({
+          nested: { epsilon: "{EPSILON-OUTER}" },
+        });
+        // dot prefix looks up from the root
+        const resolver3 = resolver1.lookup(".delta.epsilon");
+        expect(resolver3.data).toBe("{EPSILON-OUTER}");
+      });
     });
   });
 

--- a/packages/bs-protobuf/src/compiler/gen-types/resolver.js
+++ b/packages/bs-protobuf/src/compiler/gen-types/resolver.js
@@ -51,16 +51,34 @@ export class Resolver {
     return couldNotResolve;
   }
 
-  lookupPath(path) {
+  lookupPathInner(path) {
+    // Start to resolve from the inside on the chain
     let resolver = this.forwardLookupPath(path, true);
     if (!resolver.data && this.chain) {
-      resolver = this.chain.lookupPath(path);
+      resolver = this.chain.lookupPathInner(path);
+    }
+    return resolver;
+  }
+
+  lookupPathOuter(path) {
+    // Start to resolve from the root of the chain
+    let resolver = couldNotResolve;
+    if (this.chain) {
+      resolver = this.chain.lookupPathOuter(path);
+    }
+    if (!resolver.data) {
+      resolver = this.forwardLookupPath(path, true);
     }
     return resolver;
   }
 
   lookup(name) {
-    return this.lookupPath(name.split("."));
+    const path = name.split(".");
+    if (path[0] === "") {
+      return this.lookupPathOuter(path.slice(1));
+    } else {
+      return this.lookupPathInner(path);
+    }
   }
 
   get relativePath() {

--- a/packages/bs-protobuf/test/__tests__/FieldTypes3_test.res
+++ b/packages/bs-protobuf/test/__tests__/FieldTypes3_test.res
@@ -539,4 +539,80 @@ describe("Protobuf field types support", () => {
       )
     })
   })
+
+  describe("resolution", () => {
+    describe("in message", () => {
+      let v = ResolutionTest.Message.make(
+        ~inner=ResolutionTest.Message.Enum1.VInner3,
+        ~outer=ResolutionTest.Enum1.VOuter1,
+        ~nestedInner=ResolutionTest.Message.Nested.Enum1.VOuter7,
+        ~typeInner=ResolutionTest.Message.Type1.make(~inner=Some("INNER"), ()),
+        ~typeOuter=ResolutionTest.Type1.make(~outer=Some("OUTER"), ()),
+        ~nestedTypeInner=ResolutionTest.Message.Nested.Type1.make(
+          ~nestedInner=Some("NESTED-INNER"),
+          (),
+        ),
+        (),
+      )
+      test("inner", () => v.inner |> expect |> toBe(ResolutionTest.Message.Enum1.VInner3))
+      test("outer", () => v.outer |> expect |> toBe(ResolutionTest.Enum1.VOuter1))
+      test("nestedInner", () =>
+        v.nestedInner |> expect |> toBe(ResolutionTest.Message.Nested.Enum1.VOuter7)
+      )
+      // Note: nestedOuter resolution in messages is not supported by protobufjs.
+      test("typeInner", () => v.typeInner.inner |> expect |> toBe(Some("INNER")))
+      test("typeOuter", () => v.typeOuter.outer |> expect |> toBe(Some("OUTER")))
+      test("nestedTypeInner", () =>
+        v.nestedTypeInner.nestedInner |> expect |> toBe(Some("NESTED-INNER"))
+      )
+      test("encode/decode", () =>
+        v |> ResolutionTest.Message.encode |> ResolutionTest.Message.decode |> expect |> toEqual(v)
+      )
+    })
+
+    describe("in module", () => {
+      let v = Proto.ResolutionTest3.Inner.Message.make(
+        ~enumInner=Proto.ResolutionTest3.Inner.Enum1.VInner4,
+        ~enumOuter=Proto.ResolutionTest3.Enum1.VOuter1,
+        ~enumNestedInner=Proto.ResolutionTest3.Inner.Nested.Enum1.VInnerNested7,
+        ~enumNestedOuter=Proto.ResolutionTest3.Nested.Enum1.VOuterNested3,
+        ~typeInner=Proto.ResolutionTest3.Inner.Type1.make(~inner=Some("INNER"), ()),
+        ~typeOuter=Proto.ResolutionTest3.Type1.make(~outer=Some("OUTER"), ()),
+        ~typeNestedInner=Proto.ResolutionTest3.Inner.Nested.Type1.make(
+          ~innerNested=Some("INNER-NESTED"),
+          (),
+        ),
+        ~typeNestedOuter=Proto.ResolutionTest3.Nested.Type1.make(
+          ~outerNested=Some("OUTER-NESTED"),
+          (),
+        ),
+        (),
+      )
+      test("enumInner", () =>
+        v.enumInner |> expect |> toBe(Proto.ResolutionTest3.Inner.Enum1.VInner4)
+      )
+      test("enumOuter", () => v.enumOuter |> expect |> toBe(Proto.ResolutionTest3.Enum1.VOuter1))
+      test("enumNestedInner", () =>
+        v.enumNestedInner |> expect |> toBe(Proto.ResolutionTest3.Inner.Nested.Enum1.VInnerNested7)
+      )
+      test("enumNestedOuter", () =>
+        v.enumNestedOuter |> expect |> toBe(Proto.ResolutionTest3.Nested.Enum1.VOuterNested3)
+      )
+      test("typeInner", () => v.typeInner.inner |> expect |> toBe(Some("INNER")))
+      test("typeOuter", () => v.typeOuter.outer |> expect |> toBe(Some("OUTER")))
+      test("typeNestedInner", () =>
+        v.typeNestedInner.innerNested |> expect |> toBe(Some("INNER-NESTED"))
+      )
+      test("typeNestedOuter", () =>
+        v.typeNestedOuter.outerNested |> expect |> toBe(Some("OUTER-NESTED"))
+      )
+      test("encode/decode", () =>
+        v
+        |> Proto.ResolutionTest3.Inner.Message.encode
+        |> Proto.ResolutionTest3.Inner.Message.decode
+        |> expect
+        |> toEqual(v)
+      )
+    })
+  })
 })

--- a/packages/bs-protobuf/test/proto/resolution_test_inner_3.proto
+++ b/packages/bs-protobuf/test/proto/resolution_test_inner_3.proto
@@ -1,0 +1,24 @@
+
+syntax = "proto3";
+
+package resolutionTest3.Inner;
+
+message Type1 {
+  optional string inner=1;
+}
+
+enum Enum1 {
+  VInner4 = 4;
+  VInner5 = 5;
+}
+
+message Message {
+  Enum1 enumInner=1;
+  .Enum1 enumOuter=2;
+  Nested.Enum1 enumNestedInner=3;
+  .Nested.Enum1 enumNestedOuter=4;
+  Type1 typeInner=5;
+  .Type1 typeOuter=6;
+  Nested.Type1 typeNestedInner=7;
+  .Nested.Type1 typeNestedOuter=8;
+}

--- a/packages/bs-protobuf/test/proto/resolution_test_inner_nested_3.proto
+++ b/packages/bs-protobuf/test/proto/resolution_test_inner_nested_3.proto
@@ -1,0 +1,13 @@
+
+syntax = "proto3";
+
+package resolutionTest3.Inner.Nested;
+
+message Type1 {
+  optional string innerNested=1;
+}
+
+enum Enum1 {
+  VInnerNested6 = 6;
+  VInnerNested7 = 7;
+}

--- a/packages/bs-protobuf/test/proto/resolution_test_outer_3.proto
+++ b/packages/bs-protobuf/test/proto/resolution_test_outer_3.proto
@@ -1,0 +1,13 @@
+
+syntax = "proto3";
+
+package resolutionTest3;
+
+message Type1 {
+  optional string outer=1;
+}
+
+enum Enum1 {
+  VOuter0 = 0;
+  VOuter1 = 1;
+}

--- a/packages/bs-protobuf/test/proto/resolution_test_outer_nested_3.proto
+++ b/packages/bs-protobuf/test/proto/resolution_test_outer_nested_3.proto
@@ -1,0 +1,13 @@
+
+syntax = "proto3";
+
+package resolutionTest3.Nested;
+
+message Type1 {
+  optional string outerNested=1;
+}
+
+enum Enum1 {
+  VOuterNested2 = 2;
+  VOuterNested3 = 3;
+}

--- a/packages/bs-protobuf/test/proto/type_test_3.proto
+++ b/packages/bs-protobuf/test/proto/type_test_3.proto
@@ -69,3 +69,39 @@ message Nested {
     optional int32 int32Field = 2;
   }
 }
+
+message ResolutionTest {
+  enum Enum1 {
+    VOuter0 = 0;
+    VOuter1 = 1;
+  }
+  message Type1 {
+    optional string outer=1;
+  }
+  // Note: Nested outer enum and message fail to compile with protobufjs.
+  // So, these are missing from this test proto.
+  message Message {
+    enum Enum1 {
+      VInner2 = 2;
+      VInner3 = 3;
+    }
+    message Type1 {
+      optional string inner=1;
+    }
+    message Nested {
+      enum Enum1 {
+        VOuter6 = 6;
+        VOuter7 = 7;
+      }
+      message Type1 {
+        optional string nestedInner=1;
+      }
+    }
+    Enum1 inner=1;
+    .Enum1 outer=2;
+    Nested.Enum1 nestedInner=3;
+    Type1 typeInner=4;
+    .Type1 typeOuter=5;
+    Nested.Type1 nestedTypeInner=6;
+  }
+}


### PR DESCRIPTION
Supports dot references for:

- Message in message
- Enum in message
- Message in package, multi level
- Enum in package, multi level

Multi level locations for messages or enums in messages are not
supported in protobufjs, so these don't work. (Otherwise, if protobufjs
supported it, it would work with the current implementation.)

Tests are only provided for proto3, currently.