### PR TITLE
Implement make2 with strict policy for proto2 required fields

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,13 +9,13 @@ const config = {
     "/node_modules/",
     "/bs-rpc-axios/test/proto-res/",
     "/proto-demo/proto-res/",
-    "/bs-protobuf/test/proto-res/Proto.proto.js",
+    "/bs-protobuf/test/proto-res/",
   ],
   coverageThreshold: {
     global: {
-      branches: 60,
-      functions: 60,
-      lines: 70,
+      branches: 75,
+      functions: 95,
+      lines: 95,
       statements: -1000,
     },
   },

--- a/packages/bs-protobuf/src/compiler/gen-types/emit-pass1.js
+++ b/packages/bs-protobuf/src/compiler/gen-types/emit-pass1.js
@@ -236,7 +236,8 @@ ${" ".repeat(indent)}module ${resolver.flattenedName} = {
     // not typeable in rescript
     stream.write(`\
 ${" ".repeat(indent)}  type t = unit
-${" ".repeat(indent)}  let make = (()) => ()`);
+${" ".repeat(indent)}  let make = (()) => ()
+${" ".repeat(indent)}  let make2 = (()) => ()`);
   } else {
     stream.write(`\
 ${" ".repeat(indent)}  type t = {
@@ -259,7 +260,12 @@ ${" ".repeat(indent)}    @as("${fieldName}") ${decapitalize(
     stream.write(`\
 ${" ".repeat(indent)}  }
 ${" ".repeat(indent)}  let make = (`);
-    emitFieldParameters(stream, resolver, indent, false);
+    emitFieldParameters(stream, resolver, indent, false, false);
+    stream.write(`) => `);
+    emitFieldRecord(stream, resolver, indent);
+    stream.write(`
+${" ".repeat(indent)}  let make2 = (`);
+    emitFieldParameters(stream, resolver, indent, false, true);
     stream.write(`) => `);
     emitFieldRecord(stream, resolver, indent);
   }

--- a/packages/bs-protobuf/src/compiler/gen-types/emit-pass2.js
+++ b/packages/bs-protobuf/src/compiler/gen-types/emit-pass2.js
@@ -40,7 +40,12 @@ ${" ".repeat(
   indent
 )}    let call = (serviceRoot, request) => methodWrapper(wrapped, serviceRoot, request)
 ${" ".repeat(indent)}    let make = (serviceRoot, `);
-    emitFieldParameters(stream, requestResolver, indent, true);
+    emitFieldParameters(stream, requestResolver, indent, true, false);
+    stream.write(`) => methodWrapper(wrapped, serviceRoot, `);
+    emitFieldRecord(stream, requestResolver, indent);
+    stream.write(`)
+${" ".repeat(indent)}    let make2 = (serviceRoot, `);
+    emitFieldParameters(stream, requestResolver, indent, true, true);
     stream.write(`) => methodWrapper(wrapped, serviceRoot, `);
     emitFieldRecord(stream, requestResolver, indent);
     stream.write(`)

--- a/packages/bs-protobuf/test/__tests__/FieldTypes3_test.res
+++ b/packages/bs-protobuf/test/__tests__/FieldTypes3_test.res
@@ -17,6 +17,10 @@ describe("Protobuf field types support", () => {
       Basic.make(~stringField=Some("The answer"), ~int32Field=Some(42), ())->testTypeSupport
     )
 
+    describe("make2", () =>
+      Basic.make2(~stringField=Some("The answer"), ~int32Field=Some(42), ())->testTypeSupport
+    )
+
     describe("as record", () =>
       {
         stringField: Some("The answer"),
@@ -24,14 +28,21 @@ describe("Protobuf field types support", () => {
       }->testTypeSupport
     )
 
-    describe("defaults", () => {
-      let v = Basic.make()
+    let testTypeSupportEmpty = (v: Basic.t) => {
       test("string", () => v.stringField |> expect |> toBe(None))
       test("int32", () => v.int32Field |> expect |> toBe(None))
       test("encode empty", () =>
         v |> Basic.encode |> Js_typed_array.ArrayBuffer.byteLength |> expect |> toBe(0)
       )
       test("encode/decode", () => v |> Basic.encode |> Basic.decode |> expect |> toEqual(v))
+    }
+
+    describe("defaults make", () => {
+      Basic.make()->testTypeSupportEmpty
+    })
+
+    describe("defaults make2", () => {
+      Basic.make2()->testTypeSupportEmpty
     })
   })
 
@@ -47,6 +58,10 @@ describe("Protobuf field types support", () => {
       Required.make(~stringField="The answer", ~int32Field=42, ())->testTypeSupport
     )
 
+    describe("make2", () =>
+      Required.make2(~stringField="The answer", ~int32Field=42, ())->testTypeSupport
+    )
+
     describe("as record", () =>
       {
         stringField: "The answer",
@@ -54,14 +69,21 @@ describe("Protobuf field types support", () => {
       }->testTypeSupport
     )
 
-    describe("defaults", () => {
-      let v = Required.make()
+    let testTypeSupportEmpty = (v: Required.t) => {
       test("string", () => v.stringField |> expect |> toBe(""))
       test("int32", () => v.int32Field |> expect |> toBe(0))
       test("encode empty", () =>
         v |> Required.encode |> Js_typed_array.ArrayBuffer.byteLength |> expect |> toBe(4)
       )
       test("encode/decode", () => v |> Required.encode |> Required.decode |> expect |> toEqual(v))
+    }
+
+    describe("defaults make", () => {
+      Required.make()->testTypeSupportEmpty
+    })
+
+    describe("defaults make2", () => {
+      Required.make2()->testTypeSupportEmpty
     })
   })
 
@@ -83,6 +105,14 @@ describe("Protobuf field types support", () => {
       )->testTypeSupport
     )
 
+    describe("make2", () =>
+      Capitalization.make2(
+        ~stringField=Some("The answer"),
+        ~int32Field=Some(42),
+        (),
+      )->testTypeSupport
+    )
+
     describe("as record", () =>
       {
         stringField: Some("The answer"),
@@ -90,8 +120,7 @@ describe("Protobuf field types support", () => {
       }->testTypeSupport
     )
 
-    describe("defaults", () => {
-      let v = Capitalization.make()
+    let testTypeSupportEmpty = (v: Capitalization.t) => {
       test("string", () => v.stringField |> expect |> toBe(None))
       test("int32", () => v.int32Field |> expect |> toBe(None))
       test("encode empty", () =>
@@ -100,6 +129,14 @@ describe("Protobuf field types support", () => {
       test("encode/decode", () =>
         v |> Capitalization.encode |> Capitalization.decode |> expect |> toEqual(v)
       )
+    }
+
+    describe("defaults make", () => {
+      Capitalization.make()->testTypeSupportEmpty
+    })
+
+    describe("defaults make2", () => {
+      Capitalization.make2()->testTypeSupportEmpty
     })
   })
 
@@ -546,6 +583,7 @@ describe("Protobuf field types support", () => {
       test("encode/decode", () => v |> Empty.encode |> Empty.decode |> expect |> toEqual(v))
     }
     describe("make", () => Empty.make()->testTypeSupport)
+    describe("make2", () => Empty.make2()->testTypeSupport)
     describe("as unit", () => ()->testTypeSupport)
 
     describe("defaults", () => {
@@ -569,6 +607,14 @@ describe("Protobuf field types support", () => {
 
     describe("make", () =>
       Nested.Message.make(
+        ~stringField=Some("The answer"),
+        ~int32Field=Some(42),
+        (),
+      )->testTypeSupport
+    )
+
+    describe("make2", () =>
+      Nested.Message.make2(
         ~stringField=Some("The answer"),
         ~int32Field=Some(42),
         (),

--- a/packages/bs-protobuf/test/__tests__/FieldTypes_test.res
+++ b/packages/bs-protobuf/test/__tests__/FieldTypes_test.res
@@ -17,6 +17,10 @@ describe("Protobuf field types support", () => {
       Basic.make(~stringField="The answer", ~int32Field=42, ())->testTypeSupport
     )
 
+    describe("make2", () =>
+      Basic.make2(~stringField="The answer", ~int32Field=42, ())->testTypeSupport
+    )
+
     describe("as record", () =>
       {
         stringField: "The answer",
@@ -24,14 +28,21 @@ describe("Protobuf field types support", () => {
       }->testTypeSupport
     )
 
-    describe("defaults", () => {
-      let v = Basic.make()
+    let testTypeSupportEmpty = (v: Basic.t) => {
       test("string", () => v.stringField |> expect |> toBe(""))
       test("int32", () => v.int32Field |> expect |> toBe(0))
       test("encode empty", () =>
         v |> Basic.encode |> Js_typed_array.ArrayBuffer.byteLength |> expect |> toBe(4)
       )
       test("encode/decode", () => v |> Basic.encode |> Basic.decode |> expect |> toEqual(v))
+    }
+
+    describe("defaults make", () => {
+      Basic.make()->testTypeSupportEmpty
+    })
+
+    describe("defaults make2", () => {
+      Basic.make2()->testTypeSupportEmpty
     })
   })
 
@@ -45,6 +56,10 @@ describe("Protobuf field types support", () => {
 
     describe("make", () =>
       Required.make(~stringField="The answer", ~int32Field=42, ())->testTypeSupport
+    )
+
+    describe("make2", () =>
+      Required.make2(~stringField="The answer", ~int32Field=42, ())->testTypeSupport
     )
 
     describe("as record", () =>
@@ -79,6 +94,10 @@ describe("Protobuf field types support", () => {
       Capitalization.make(~stringField="The answer", ~int32Field=42, ())->testTypeSupport
     )
 
+    describe("make2", () =>
+      Capitalization.make(~stringField="The answer", ~int32Field=42, ())->testTypeSupport
+    )
+
     describe("as record", () =>
       {
         stringField: "The answer",
@@ -86,8 +105,7 @@ describe("Protobuf field types support", () => {
       }->testTypeSupport
     )
 
-    describe("defaults", () => {
-      let v = Capitalization.make()
+    let testTypeSupportEmpty = (v: Capitalization.t) => {
       test("string", () => v.stringField |> expect |> toBe(""))
       test("int32", () => v.int32Field |> expect |> toBe(0))
       test("encode empty", () =>
@@ -96,6 +114,14 @@ describe("Protobuf field types support", () => {
       test("encode/decode", () =>
         v |> Capitalization.encode |> Capitalization.decode |> expect |> toEqual(v)
       )
+    }
+
+    describe("defaults make", () => {
+      Capitalization.make()->testTypeSupportEmpty
+    })
+
+    describe("defaults make2", () => {
+      Capitalization.make2()->testTypeSupportEmpty
     })
   })
 
@@ -589,6 +615,7 @@ describe("Protobuf field types support", () => {
       test("encode/decode", () => v |> Empty.encode |> Empty.decode |> expect |> toEqual(v))
     }
     describe("make", () => Empty.make()->testTypeSupport)
+    describe("make2", () => Empty.make2()->testTypeSupport)
     describe("as unit", () => ()->testTypeSupport)
 
     describe("defaults", () => {
@@ -614,6 +641,10 @@ describe("Protobuf field types support", () => {
       Nested.Message.make(~stringField="The answer", ~int32Field=42, ())->testTypeSupport
     )
 
+    describe("make2", () =>
+      Nested.Message.make2(~stringField="The answer", ~int32Field=42, ())->testTypeSupport
+    )
+
     describe("as record", () =>
       {
         stringField: "The answer",
@@ -621,8 +652,7 @@ describe("Protobuf field types support", () => {
       }->testTypeSupport
     )
 
-    describe("defaults", () => {
-      let v = Nested.Message.make()
+    let testTypeSupportEmpty = (v: Nested.Message.t) => {
       test("string", () => v.stringField |> expect |> toBe(""))
       test("int32", () => v.int32Field |> expect |> toBe(0))
       test("encode empty", () =>
@@ -631,6 +661,14 @@ describe("Protobuf field types support", () => {
       test("encode/decode", () =>
         v |> Nested.Message.encode |> Nested.Message.decode |> expect |> toEqual(v)
       )
+    }
+
+    describe("defaults make", () => {
+      Nested.Message.make()->testTypeSupportEmpty
+    })
+
+    describe("defaults make2", () => {
+      Nested.Message.make2()->testTypeSupportEmpty
     })
   })
 })


### PR DESCRIPTION
- leave make intact and implement make2
- add tests
- relieve coverage check from Proto.bs.js, and increase coverage
  threshold globally, in return