### PR TITLE
Add --with-make2 option, make2 generation only as an option

### DIFF
--- a/packages/bs-protobuf/package.json
+++ b/packages/bs-protobuf/package.json
@@ -22,8 +22,8 @@
     "protores": "src/script/protores.js"
   },
   "scripts": {
-    "protores:build": "mkdir -p test/proto-res && yarn protores -v test/proto/*.proto -o test/proto-res/Proto.res",
-    "protores:dev": "mkdir -p test/proto-res && yarn protores -w -s -v test/proto/*.proto -o test/proto-res/Proto.res",
+    "protores:build": "mkdir -p test/proto-res && yarn protores -m -v test/proto/*.proto -o test/proto-res/Proto.res && yarn protores -v test/proto/*.proto -o test/proto-res/ProtoWithoutMake2.res ",
+    "protores:dev": "mkdir -p test/proto-res && yarn protores -w -s -m -v test/proto/*.proto -o test/proto-res/Proto.res & yarn protores -w -s -v test/proto/*.proto -o test/proto-res/ProtoWithoutMake2.res",
     "build": "yarn protores:build",
     "dev": "yarn protores:dev"
   },

--- a/packages/bs-protobuf/src/compiler/compiler-cli.js
+++ b/packages/bs-protobuf/src/compiler/compiler-cli.js
@@ -44,6 +44,12 @@ export async function protoRes() {
       description: "Verbose logging",
       default: false,
     })
+    .option("withMake2", {
+      alias: "m",
+      type: "boolean",
+      description: "Generate make2 helper function",
+      default: false,
+    })
     .strictOptions()
     .check(function (argv) {
       if (argv._.length === 0) {
@@ -81,6 +87,7 @@ export async function genCli({
   watch,
   skipInitial,
   verbose,
+  withMake2,
 }) {
   const doIt = async () => {
     await genAll({
@@ -88,6 +95,7 @@ export async function genCli({
       includes,
       output,
       verbose,
+      withMake2,
     });
   };
   const doItProtected = async () => {
@@ -115,11 +123,11 @@ export async function genCli({
   }
 }
 
-async function genAll({ filenames, includes, output, verbose }) {
+async function genAll({ filenames, includes, output, verbose, withMake2 }) {
   const jsOutput = makeJsOutput(output);
   const jsOutputRelative = "./" + path.basename(jsOutput);
   await genProto(filenames, includes, jsOutput);
-  await genTypes(filenames, includes, jsOutputRelative, output);
+  await genTypes(filenames, includes, jsOutputRelative, output, withMake2);
   if (verbose) {
     console.log(
       `Protores generated outputs ${emphasized(output)} and ${emphasized(

--- a/packages/bs-protobuf/src/compiler/gen-types/__tests__/resolver-test.js
+++ b/packages/bs-protobuf/src/compiler/gen-types/__tests__/resolver-test.js
@@ -5,7 +5,7 @@ import { Resolver, couldNotResolve, specialModuleTypes } from "../resolver";
 function expectCouldNotResolve(resolver) {
   expect(resolver).toBe(couldNotResolve);
   expect(resolver.data).toBe(undefined);
-  expect(resolver.protoJsPath).toBe(undefined);
+  expect(resolver.options).toBe(undefined);
   expect(resolver.chain).toBe(null);
   expect(resolver.prefix).toEqual([]);
   expect(resolver.baseLevel).toEqual(null);
@@ -13,9 +13,9 @@ function expectCouldNotResolve(resolver) {
 
 describe("gen-types Resolver", () => {
   test("constructor", () => {
-    const resolver = new Resolver("{DATA}", "PROTO_JS_PATH");
+    const resolver = new Resolver("{DATA}", "<OPTIONS>");
     expect(resolver.data).toBe("{DATA}");
-    expect(resolver.protoJsPath).toBe("PROTO_JS_PATH");
+    expect(resolver.options).toBe("<OPTIONS>");
     expect(resolver.chain).toBe(null);
     expect(resolver.prefix).toEqual([]);
     expect(resolver.baseLevel).toEqual(null);
@@ -25,17 +25,17 @@ describe("gen-types Resolver", () => {
     test("hit", () => {
       const resolver = new Resolver(
         { nested: { alpha: { nested: { beta: "{BETA}" } } } },
-        "PROTO_JS_PATH"
+        "<OPTIONS>"
       );
       const resolver1 = resolver.next("alpha");
       expect(resolver1.data).toEqual({ nested: { beta: "{BETA}" } });
-      expect(resolver1.protoJsPath).toBe("PROTO_JS_PATH");
+      expect(resolver1.options).toBe("<OPTIONS>");
       expect(resolver1.chain).toBe(resolver);
       expect(resolver1.prefix).toEqual(["alpha"]);
       expect(resolver1.baseLevel).toEqual(null);
       const resolver2 = resolver1.next("beta");
       expect(resolver2.data).toEqual("{BETA}");
-      expect(resolver2.protoJsPath).toBe("PROTO_JS_PATH");
+      expect(resolver2.options).toBe("<OPTIONS>");
       expect(resolver2.chain).toBe(resolver1);
       expect(resolver2.prefix).toEqual(["alpha", "beta"]);
       expect(resolver2.baseLevel).toEqual(null);
@@ -44,7 +44,7 @@ describe("gen-types Resolver", () => {
     test("miss", () => {
       const resolver = new Resolver(
         { nested: { alpha: { nested: { beta: "{BETA}" } } } },
-        "PROTO_JS_PATH"
+        "<OPTIONS>"
       );
       const resolver1 = resolver.next("NOSUCH");
       expectCouldNotResolve(resolver1);
@@ -58,11 +58,11 @@ describe("gen-types Resolver", () => {
     test("hit", () => {
       const resolver = new Resolver(
         { nested: { alpha: { nested: { beta: "{BETA}" } } } },
-        "PROTO_JS_PATH"
+        "<OPTIONS>"
       );
       const resolver1 = resolver.lookup("alpha.beta");
       expect(resolver1.data).toEqual("{BETA}");
-      expect(resolver1.protoJsPath).toBe("PROTO_JS_PATH");
+      expect(resolver1.options).toBe("<OPTIONS>");
       expect(resolver1.chain.chain).toBe(resolver);
       expect(resolver1.relativePath).toEqual("Alpha.Beta");
     });
@@ -74,15 +74,15 @@ describe("gen-types Resolver", () => {
             alpha: { nested: { beta: { nested: { gamma: "{GAMMA}" } } } },
           },
         },
-        "PROTO_JS_PATH"
+        "<OPTIONS>"
       );
       const resolver1 = resolver.lookup("alpha");
-      expect(resolver1.protoJsPath).toBe("PROTO_JS_PATH");
+      expect(resolver1.options).toBe("<OPTIONS>");
       expect(resolver1.chain).toBe(resolver);
       expect(resolver1.relativePath).toEqual("Alpha");
       const resolver2 = resolver1.lookup("beta.gamma");
       expect(resolver2.data).toEqual("{GAMMA}");
-      expect(resolver2.protoJsPath).toBe("PROTO_JS_PATH");
+      expect(resolver2.options).toBe("<OPTIONS>");
       expect(resolver2.chain.chain).toBe(resolver1);
       expect(resolver2.relativePath).toEqual("Alpha.Beta.Gamma");
     });
@@ -90,7 +90,7 @@ describe("gen-types Resolver", () => {
     test("miss", () => {
       const resolver = new Resolver(
         { nested: { alpha: { nested: { beta: "{BETA}" } } } },
-        "PROTO_JS_PATH"
+        "<OPTIONS>"
       );
       const resolver1 = resolver.lookup("alpha.gamma");
       expectCouldNotResolve(resolver1);
@@ -109,18 +109,18 @@ describe("gen-types Resolver", () => {
               },
             },
           },
-          "PROTO_JS_PATH"
+          "<OPTIONS>"
         );
         const resolver1 = resolver.lookup("alpha.beta.gamma");
-        expect(resolver1.protoJsPath).toBe("PROTO_JS_PATH");
+        expect(resolver1.options).toBe("<OPTIONS>");
         expect(resolver1.chain.chain.chain).toBe(resolver);
         expect(resolver1.relativePath).toEqual("Alpha.Beta.Gamma");
         const resolver2 = resolver1.lookup("delta");
-        expect(resolver2.protoJsPath).toBe("PROTO_JS_PATH");
+        expect(resolver2.options).toBe("<OPTIONS>");
         expect(resolver2.chain.chain).toBe(resolver);
         expect(resolver2.relativePath).toEqual("Alpha.Delta");
         const resolver3 = resolver1.lookup("delta.epsilon");
-        expect(resolver3.protoJsPath).toBe("PROTO_JS_PATH");
+        expect(resolver3.options).toBe("<OPTIONS>");
         expect(resolver3.chain.chain.chain).toBe(resolver);
         expect(resolver3.relativePath).toEqual("Alpha.Delta.Epsilon");
       });
@@ -137,18 +137,18 @@ describe("gen-types Resolver", () => {
               },
             },
           },
-          "PROTO_JS_PATH"
+          "<OPTIONS>"
         );
         const resolver1 = resolver.next("alpha").next("beta").next("gamma");
-        expect(resolver1.protoJsPath).toBe("PROTO_JS_PATH");
+        expect(resolver1.options).toBe("<OPTIONS>");
         expect(resolver1.chain.chain.chain).toBe(resolver);
         expect(resolver1.relativePath).toEqual("Alpha.Beta.Gamma");
         const resolver2 = resolver1.lookup("delta");
-        expect(resolver2.protoJsPath).toBe("PROTO_JS_PATH");
+        expect(resolver2.options).toBe("<OPTIONS>");
         expect(resolver2.chain.chain).toBe(resolver);
         expect(resolver2.relativePath).toEqual("Delta");
         const resolver3 = resolver1.lookup("delta.epsilon");
-        expect(resolver3.protoJsPath).toBe("PROTO_JS_PATH");
+        expect(resolver3.options).toBe("<OPTIONS>");
         expect(resolver3.chain.chain.chain).toBe(resolver);
         expect(resolver3.relativePath).toEqual("Delta.Epsilon");
       });
@@ -165,18 +165,18 @@ describe("gen-types Resolver", () => {
               },
             },
           },
-          "PROTO_JS_PATH"
+          "<OPTIONS>"
         );
         const resolver1 = resolver.next("alpha").next("beta").next("gamma");
-        expect(resolver1.protoJsPath).toBe("PROTO_JS_PATH");
+        expect(resolver1.options).toBe("<OPTIONS>");
         expect(resolver1.chain.chain.chain).toBe(resolver);
         expect(resolver1.relativePath).toEqual("Alpha.Beta.Gamma");
         const resolver2 = resolver1.lookup("beta");
-        expect(resolver2.protoJsPath).toBe("PROTO_JS_PATH");
+        expect(resolver2.options).toBe("<OPTIONS>");
         expect(resolver2.chain.chain).toBe(resolver);
         expect(resolver2.relativePath).toEqual("Beta");
         const resolver3 = resolver2.lookup("delta.epsilon");
-        expect(resolver3.protoJsPath).toBe("PROTO_JS_PATH");
+        expect(resolver3.options).toBe("<OPTIONS>");
         expect(resolver3.chain.chain.chain).toBe(resolver);
         expect(resolver3.relativePath).toEqual("Delta.Epsilon");
       });
@@ -194,7 +194,7 @@ describe("gen-types Resolver", () => {
               delta: { nested: { epsilon: "{EPSILON-OUTER}" } },
             },
           },
-          "PROTO_JS_PATH"
+          "<OPTIONS>"
         );
         const resolver1 = resolver.next("alpha").next("beta").next("gamma");
         const resolver2 = resolver1.lookup("delta");
@@ -218,7 +218,7 @@ describe("gen-types Resolver", () => {
               delta: { nested: { epsilon: "{EPSILON-OUTER}" } },
             },
           },
-          "PROTO_JS_PATH"
+          "<OPTIONS>"
         );
         const resolver1 = resolver.next("alpha").next("beta").next("gamma");
         // dot prefix looks up from the root

--- a/packages/bs-protobuf/src/compiler/gen-types/emit-pass1.js
+++ b/packages/bs-protobuf/src/compiler/gen-types/emit-pass1.js
@@ -236,8 +236,11 @@ ${" ".repeat(indent)}module ${resolver.flattenedName} = {
     // not typeable in rescript
     stream.write(`\
 ${" ".repeat(indent)}  type t = unit
-${" ".repeat(indent)}  let make = (()) => ()
+${" ".repeat(indent)}  let make = (()) => ()`);
+    if (resolver.options.withMake2) {
+      stream.write(`
 ${" ".repeat(indent)}  let make2 = (()) => ()`);
+    }
   } else {
     stream.write(`\
 ${" ".repeat(indent)}  type t = {
@@ -263,11 +266,13 @@ ${" ".repeat(indent)}  let make = (`);
     emitFieldParameters(stream, resolver, indent, false, false);
     stream.write(`) => `);
     emitFieldRecord(stream, resolver, indent);
-    stream.write(`
+    if (resolver.options.withMake2) {
+      stream.write(`
 ${" ".repeat(indent)}  let make2 = (`);
-    emitFieldParameters(stream, resolver, indent, false, true);
-    stream.write(`) => `);
-    emitFieldRecord(stream, resolver, indent);
+      emitFieldParameters(stream, resolver, indent, false, true);
+      stream.write(`) => `);
+      emitFieldRecord(stream, resolver, indent);
+    }
   }
   stream.write(`
 ${" ".repeat(indent)}  `);
@@ -357,7 +362,7 @@ ${" ".repeat(indent)}}
 }
 
 function emitProtoModuleDirective(stream, resolver) {
-  stream.write(`@module("${resolver.protoJsPath}") `);
+  stream.write(`@module("${resolver.options.protoJsPath}") `);
 }
 
 function emitEntityPass1(stream, resolver, indent) {

--- a/packages/bs-protobuf/src/compiler/gen-types/emit-pass2.js
+++ b/packages/bs-protobuf/src/compiler/gen-types/emit-pass2.js
@@ -44,11 +44,17 @@ ${" ".repeat(indent)}    let make = (serviceRoot, `);
     stream.write(`) => methodWrapper(wrapped, serviceRoot, `);
     emitFieldRecord(stream, requestResolver, indent);
     stream.write(`)
+`);
+    if (requestResolver.options.withMake2) {
+      stream.write(`\
 ${" ".repeat(indent)}    let make2 = (serviceRoot, `);
-    emitFieldParameters(stream, requestResolver, indent, true, true);
-    stream.write(`) => methodWrapper(wrapped, serviceRoot, `);
-    emitFieldRecord(stream, requestResolver, indent);
-    stream.write(`)
+      emitFieldParameters(stream, requestResolver, indent, true, true);
+      stream.write(`) => methodWrapper(wrapped, serviceRoot, `);
+      emitFieldRecord(stream, requestResolver, indent);
+      stream.write(`)
+`);
+    }
+    stream.write(`\
 ${" ".repeat(indent)}  }
 `);
   }
@@ -72,7 +78,7 @@ ${" ".repeat(indent)}}
 }
 
 function emitProtoModuleDirective(stream, resolver) {
-  stream.write(`@module("${resolver.protoJsPath}") `);
+  stream.write(`@module("${resolver.options.protoJsPath}") `);
 }
 
 export function emitPackagePass2(stream, parentResolver, indent = 0) {

--- a/packages/bs-protobuf/src/compiler/gen-types/emit-types.js
+++ b/packages/bs-protobuf/src/compiler/gen-types/emit-types.js
@@ -34,7 +34,7 @@ function emitBetweenPasses(stream, resolver) {
 }
 
 function emitProtoModuleDirective(stream, resolver) {
-  stream.write(`@module("${resolver.protoJsPath}") `);
+  stream.write(`@module("${resolver.options.protoJsPath}") `);
 }
 
 function emitEpilogue(stream, resolver) {}

--- a/packages/bs-protobuf/src/compiler/gen-types/gen-proto.js
+++ b/packages/bs-protobuf/src/compiler/gen-types/gen-proto.js
@@ -53,9 +53,15 @@ export function genProtoData(filenames, includes) {
   });
 }
 
-export async function genTypes(filenames, includes, protoJsPath, output) {
+export async function genTypes(
+  filenames,
+  includes,
+  protoJsPath,
+  output,
+  withMake2
+) {
   const data = await genProtoData(filenames, includes);
-  const resolver = new Resolver(data, protoJsPath);
+  const resolver = new Resolver(data, { protoJsPath, withMake2 });
   const stream = fs.createWriteStream(output);
   await new Promise((resolve, reject) => {
     stream.once("open", function (fd) {

--- a/packages/bs-protobuf/src/compiler/gen-types/resolver.js
+++ b/packages/bs-protobuf/src/compiler/gen-types/resolver.js
@@ -3,9 +3,9 @@ import { capitalize } from "./capitalize";
 export const specialModuleTypes = "PROTORES__Types__";
 
 export class Resolver {
-  constructor(data, protoJsPath, chain = null, prefix = [], baseLevel = null) {
+  constructor(data, options, chain = null, prefix = [], baseLevel = null) {
     this.data = data;
-    this.protoJsPath = protoJsPath;
+    this.options = options;
     this.chain = chain;
     this.prefix = prefix;
     // Base level is the length of prefix
@@ -29,7 +29,7 @@ export class Resolver {
       }
       return new Resolver(
         data,
-        this.protoJsPath,
+        this.options,
         this,
         this.prefix.concat(segment),
         baseLevel

--- a/packages/bs-protobuf/test/__tests__/WithoutMake2.res
+++ b/packages/bs-protobuf/test/__tests__/WithoutMake2.res
@@ -1,0 +1,78 @@
+open Jest
+open Expect
+
+describe("Protobuf compilation without make2", () => {
+  open ProtoWithoutMake2.TypeTest3
+
+  // Only test the elementary features here, most importantly this will
+  // prove that the generated code compiles.
+
+  describe("basic", () => {
+    let testTypeSupport = (v: Basic.t) => {
+      test("string", () => v.stringField |> expect |> toBe(Some("The answer")))
+      test("int32", () => v.int32Field |> expect |> toBe(Some(42)))
+      // test("verify", () => v |> Basic.verify |> expect |> toBe(None))
+      test("encode/decode", () => v |> Basic.encode |> Basic.decode |> expect |> toEqual(v))
+    }
+
+    describe("make", () =>
+      Basic.make(~stringField=Some("The answer"), ~int32Field=Some(42), ())->testTypeSupport
+    )
+
+    describe("as record", () =>
+      {
+        stringField: Some("The answer"),
+        int32Field: Some(42),
+      }->testTypeSupport
+    )
+
+    let testTypeSupportEmpty = (v: Basic.t) => {
+      test("string", () => v.stringField |> expect |> toBe(None))
+      test("int32", () => v.int32Field |> expect |> toBe(None))
+      test("encode empty", () =>
+        v |> Basic.encode |> Js_typed_array.ArrayBuffer.byteLength |> expect |> toBe(0)
+      )
+      test("encode/decode", () => v |> Basic.encode |> Basic.decode |> expect |> toEqual(v))
+    }
+
+    describe("defaults make", () => {
+      Basic.make()->testTypeSupportEmpty
+    })
+
+  })
+
+  describe("required", () => {
+    let testTypeSupport = (v: Required.t) => {
+      test("string", () => v.stringField |> expect |> toBe("The answer"))
+      test("int32", () => v.int32Field |> expect |> toBe(42))
+      // test("verify", () => v |> Required.verify |> expect |> toBe(None))
+      test("encode/decode", () => v |> Required.encode |> Required.decode |> expect |> toEqual(v))
+    }
+
+    describe("make", () =>
+      Required.make(~stringField="The answer", ~int32Field=42, ())->testTypeSupport
+    )
+
+    describe("as record", () =>
+      {
+        stringField: "The answer",
+        int32Field: 42,
+      }->testTypeSupport
+    )
+
+    let testTypeSupportEmpty = (v: Required.t) => {
+      test("string", () => v.stringField |> expect |> toBe(""))
+      test("int32", () => v.int32Field |> expect |> toBe(0))
+      test("encode empty", () =>
+        v |> Required.encode |> Js_typed_array.ArrayBuffer.byteLength |> expect |> toBe(4)
+      )
+      test("encode/decode", () => v |> Required.encode |> Required.decode |> expect |> toEqual(v))
+    }
+
+    describe("defaults make", () => {
+      Required.make()->testTypeSupportEmpty
+    })
+
+  })
+
+})

--- a/packages/bs-rpc-axios/package.json
+++ b/packages/bs-rpc-axios/package.json
@@ -18,8 +18,8 @@
   },
   "main": "src/index",
   "scripts": {
-    "protores:build": "mkdir -p test/proto-res && yarn protores -v test/proto/*.proto -o test/proto-res/ProtoRpcAxios.res",
-    "protores:dev": "mkdir -p test/proto-res && yarn protores -w -s -v test/proto/*.proto -o test/proto-res/ProtoRpcAxios.res",
+    "protores:build": "mkdir -p test/proto-res && yarn protores -m -v test/proto/*.proto -o test/proto-res/ProtoRpcAxios.res",
+    "protores:dev": "mkdir -p test/proto-res && yarn protores -w -s -m -v test/proto/*.proto -o test/proto-res/ProtoRpcAxios.res",
     "build": "yarn protores:build",
     "dev": "yarn protores:dev"
   },

--- a/packages/proto-demo/package.json
+++ b/packages/proto-demo/package.json
@@ -17,8 +17,8 @@
     "yarn": ">=3.0.1"
   },
   "scripts": {
-    "protores:build": "mkdir -p src/proto-res; yarn protores -v src/proto/*.proto -o src/proto-res/ProtoDemo.res",
-    "protores:dev": "mkdir -p src/proto-res; yarn protores -w -s -w src/proto/*.proto -o src/proto-res/ProtoDemo.res",
+    "protores:build": "mkdir -p src/proto-res; yarn protores -m -v src/proto/*.proto -o src/proto-res/ProtoDemo.res",
+    "protores:dev": "mkdir -p src/proto-res; yarn protores -w -s -m -v src/proto/*.proto -o src/proto-res/ProtoDemo.res",
     "webpack:build": "yarn webpack build",
     "webpack:dev": "yarn webpack serve",
     "build": "yarn protores:build && yarn webpack:build",


### PR DESCRIPTION
- Introduce compilation option for optionality of make2
- Default false, to save space in compiled code
- Add tests against syntax errors in generated code without make2